### PR TITLE
Subscripts for slices

### DIFF
--- a/src/Oden/Backend/Go.hs
+++ b/src/Oden/Backend/Go.hs
@@ -139,8 +139,8 @@ codegenUnaryOperator o = text (show o)
 codegenExpr :: Expr Mono.Type -> Doc
 codegenExpr (Symbol _ i _) =
   codegenIdentifier i
-codegenExpr (Subscript _ a is _) =
-  codegenExpr a <> (hcat (map (brackets . codegenExpr) is))
+codegenExpr (Subscript _ a i _) =
+  codegenExpr a <> (brackets . codegenExpr) i
 codegenExpr (UnaryOp _ o e _) =
   parens (codegenUnaryOperator o <+> codegenExpr e)
 codegenExpr (BinaryOp _ o e1 e2 _) =

--- a/src/Oden/Backend/Go.hs
+++ b/src/Oden/Backend/Go.hs
@@ -139,6 +139,8 @@ codegenUnaryOperator o = text (show o)
 codegenExpr :: Expr Mono.Type -> Doc
 codegenExpr (Symbol _ i _) =
   codegenIdentifier i
+codegenExpr (Subscript _ a is _) =
+  codegenExpr a <> (hcat (map (brackets . codegenExpr) is))
 codegenExpr (UnaryOp _ o e _) =
   parens (codegenUnaryOperator o <+> codegenExpr e)
 codegenExpr (BinaryOp _ o e1 e2 _) =

--- a/src/Oden/Compiler/Instantiate.hs
+++ b/src/Oden/Compiler/Instantiate.hs
@@ -87,14 +87,18 @@ replace (Poly.TSlice si t) = Poly.TSlice si <$> replace t
 
 instantiateExpr :: Core.Expr Poly.Type
                 -> Instantiate (Core.Expr Poly.Type)
+instantiateExpr (Core.Symbol si i t) =
+  Core.Symbol si i <$> replace t
+instantiateExpr (Core.Subscript si a is t) =
+  Core.Subscript si <$> instantiateExpr a
+                    <*> mapM instantiateExpr is
+                    <*> replace t
 instantiateExpr (Core.UnaryOp si o e t) = 
   Core.UnaryOp si o <$> instantiateExpr e <*> replace t
 instantiateExpr (Core.BinaryOp si o e1 e2 t) =
   Core.BinaryOp si o <$> instantiateExpr e1
                <*> instantiateExpr e2
                <*> replace t
-instantiateExpr (Core.Symbol si i t) =
-  Core.Symbol si i <$> replace t
 instantiateExpr (Core.Application si f p t) =
   Core.Application si <$> instantiateExpr f
                       <*> instantiateExpr p

--- a/src/Oden/Compiler/Instantiate.hs
+++ b/src/Oden/Compiler/Instantiate.hs
@@ -89,9 +89,9 @@ instantiateExpr :: Core.Expr Poly.Type
                 -> Instantiate (Core.Expr Poly.Type)
 instantiateExpr (Core.Symbol si i t) =
   Core.Symbol si i <$> replace t
-instantiateExpr (Core.Subscript si a is t) =
+instantiateExpr (Core.Subscript si a i t) =
   Core.Subscript si <$> instantiateExpr a
-                    <*> mapM instantiateExpr is
+                    <*> instantiateExpr i
                     <*> replace t
 instantiateExpr (Core.UnaryOp si o e t) = 
   Core.UnaryOp si o <$> instantiateExpr e <*> replace t

--- a/src/Oden/Compiler/Monomorphization.hs
+++ b/src/Oden/Compiler/Monomorphization.hs
@@ -140,6 +140,11 @@ monomorph e@(Core.Symbol si ident _) = do
   mt <- getMonoType e
   m <- getMonomorphic ident mt
   return (Core.Symbol si m mt)
+monomorph e@(Core.Subscript si a is _) = do
+  mt <- getMonoType e
+  ma <- monomorph a
+  mis <- mapM monomorph is
+  return (Core.Subscript si ma mis mt)
 monomorph e@(Core.UnaryOp si o e1 _) = do
   mt <- getMonoType e
   me <- monomorph e1

--- a/src/Oden/Compiler/Monomorphization.hs
+++ b/src/Oden/Compiler/Monomorphization.hs
@@ -140,11 +140,11 @@ monomorph e@(Core.Symbol si ident _) = do
   mt <- getMonoType e
   m <- getMonomorphic ident mt
   return (Core.Symbol si m mt)
-monomorph e@(Core.Subscript si a is _) = do
+monomorph e@(Core.Subscript si a i _) = do
   mt <- getMonoType e
   ma <- monomorph a
-  mis <- mapM monomorph is
-  return (Core.Subscript si ma mis mt)
+  mi <- monomorph i
+  return (Core.Subscript si ma mi mt)
 monomorph e@(Core.UnaryOp si o e1 _) = do
   mt <- getMonoType e
   me <- monomorph e1

--- a/src/Oden/Compiler/Validation.hs
+++ b/src/Oden/Compiler/Validation.hs
@@ -34,9 +34,9 @@ withName = local . Set.insert
 
 validateExpr :: Expr Type -> Validate ()
 validateExpr Symbol{} = return ()
-validateExpr (Subscript _ a is _) = do
+validateExpr (Subscript _ a i _) = do
   validateExpr a
-  mapM_ validateExpr is
+  validateExpr i
 validateExpr (UnaryOp _ _ rhs _) =
   validateExpr rhs
 validateExpr (BinaryOp _ _ lhs rhs _) = do

--- a/src/Oden/Compiler/Validation.hs
+++ b/src/Oden/Compiler/Validation.hs
@@ -34,6 +34,9 @@ withName = local . Set.insert
 
 validateExpr :: Expr Type -> Validate ()
 validateExpr Symbol{} = return ()
+validateExpr (Subscript _ a is _) = do
+  validateExpr a
+  mapM_ validateExpr is
 validateExpr (UnaryOp _ _ rhs _) =
   validateExpr rhs
 validateExpr (BinaryOp _ _ lhs rhs _) = do

--- a/src/Oden/Core.hs
+++ b/src/Oden/Core.hs
@@ -10,6 +10,7 @@ data Binding = Binding SourceInfo Name
               deriving (Show, Eq, Ord)
 
 data Expr t = Symbol SourceInfo Identifier t
+            | Subscript SourceInfo (Expr t) [Expr t] t
             | UnaryOp SourceInfo UnaryOperator (Expr t) t
             | BinaryOp SourceInfo BinaryOperator (Expr t) (Expr t) t
             | Application SourceInfo (Expr t) (Expr t) t
@@ -27,6 +28,7 @@ data Expr t = Symbol SourceInfo Identifier t
 
 instance HasSourceInfo (Expr t) where
   getSourceInfo (Symbol si _ _)                   = si
+  getSourceInfo (Subscript si _ _ _)              = si
   getSourceInfo (UnaryOp si _ _ _)                = si
   getSourceInfo (BinaryOp si _ _ _ _)             = si
   getSourceInfo (Application si _ _ _)            = si
@@ -42,6 +44,7 @@ instance HasSourceInfo (Expr t) where
   getSourceInfo (Block si _ _)                    = si
 
   setSourceInfo si (Symbol _ i t)                   = Symbol si i t
+  setSourceInfo si (Subscript _ b is t)             = Subscript si b is t
   setSourceInfo si (UnaryOp _ o r t)                = UnaryOp si o r t
   setSourceInfo si (BinaryOp _ p l r t)             = BinaryOp si p l r t
   setSourceInfo si (Application _ f a t)            = Application si f a t
@@ -58,6 +61,7 @@ instance HasSourceInfo (Expr t) where
 
 typeOf :: Expr t -> t
 typeOf (Symbol _ _ t) = t
+typeOf (Subscript _ _ _ t) = t
 typeOf (UnaryOp _ _ _ t) = t
 typeOf (BinaryOp _ _ _ _ t) = t
 typeOf (Application _ _ _ t) = t

--- a/src/Oden/Core.hs
+++ b/src/Oden/Core.hs
@@ -10,7 +10,7 @@ data Binding = Binding SourceInfo Name
               deriving (Show, Eq, Ord)
 
 data Expr t = Symbol SourceInfo Identifier t
-            | Subscript SourceInfo (Expr t) [Expr t] t
+            | Subscript SourceInfo (Expr t) (Expr t) t
             | UnaryOp SourceInfo UnaryOperator (Expr t) t
             | BinaryOp SourceInfo BinaryOperator (Expr t) (Expr t) t
             | Application SourceInfo (Expr t) (Expr t) t

--- a/src/Oden/Core/Untyped.hs
+++ b/src/Oden/Core/Untyped.hs
@@ -9,6 +9,7 @@ data Binding = Binding SourceInfo Name
              deriving (Show, Eq, Ord)
 
 data Expr = Symbol SourceInfo Identifier
+          | Subscript SourceInfo Expr [Expr]
           | UnaryOp SourceInfo UnaryOperator Expr
           | BinaryOp SourceInfo BinaryOperator Expr Expr
           | Application SourceInfo Expr [Expr]
@@ -24,6 +25,7 @@ data Expr = Symbol SourceInfo Identifier
 
 instance HasSourceInfo Expr where
   getSourceInfo (Symbol si _)                   = si
+  getSourceInfo (Subscript si _ _)              = si
   getSourceInfo (UnaryOp si _ _)                = si
   getSourceInfo (BinaryOp si _ _ _)             = si
   getSourceInfo (Application si _ _)            = si
@@ -37,6 +39,7 @@ instance HasSourceInfo Expr where
   getSourceInfo (Block si _)                    = si
 
   setSourceInfo si (Symbol _ i)                   = Symbol si i
+  setSourceInfo si (Subscript _ a is)             = Subscript si a is
   setSourceInfo si (UnaryOp _ p r)                = UnaryOp si p r
   setSourceInfo si (BinaryOp _ p l r)             = BinaryOp si p l r
   setSourceInfo si (Application _ f a)            = Application si f a

--- a/src/Oden/Core/Untyped.hs
+++ b/src/Oden/Core/Untyped.hs
@@ -9,7 +9,7 @@ data Binding = Binding SourceInfo Name
              deriving (Show, Eq, Ord)
 
 data Expr = Symbol SourceInfo Identifier
-          | Subscript SourceInfo Expr [Expr]
+          | Subscript SourceInfo Expr Expr
           | UnaryOp SourceInfo UnaryOperator Expr
           | BinaryOp SourceInfo BinaryOperator Expr Expr
           | Application SourceInfo Expr [Expr]

--- a/src/Oden/Explode.hs
+++ b/src/Oden/Explode.hs
@@ -23,8 +23,10 @@ explodeBinding :: Binding -> Untyped.Binding
 explodeBinding (Binding si name) = Untyped.Binding si name
 
 explodeExpr :: Expr -> Untyped.Expr
-explodeExpr (Subscript si a is) =
-  Untyped.Subscript si (explodeExpr a) (map explodeExpr is)
+explodeExpr (Subscript si a (i:[])) =
+  Untyped.Subscript si (explodeExpr a) (explodeExpr i)
+explodeExpr (Subscript si a (i:ir)) =
+  explodeExpr (Subscript si (Subscript si a [i]) ir)
 explodeExpr (UnaryOp si o e) =
   Untyped.UnaryOp si o (explodeExpr e)
 explodeExpr (BinaryOp si o e1 e2) =

--- a/src/Oden/Explode.hs
+++ b/src/Oden/Explode.hs
@@ -23,6 +23,8 @@ explodeBinding :: Binding -> Untyped.Binding
 explodeBinding (Binding si name) = Untyped.Binding si name
 
 explodeExpr :: Expr -> Untyped.Expr
+explodeExpr (Subscript si a is) =
+  Untyped.Subscript si (explodeExpr a) (map explodeExpr is)
 explodeExpr (UnaryOp si o e) =
   Untyped.UnaryOp si o (explodeExpr e)
 explodeExpr (BinaryOp si o e1 e2) =

--- a/src/Oden/Explode.hs
+++ b/src/Oden/Explode.hs
@@ -23,7 +23,7 @@ explodeBinding :: Binding -> Untyped.Binding
 explodeBinding (Binding si name) = Untyped.Binding si name
 
 explodeExpr :: Expr -> Untyped.Expr
-explodeExpr (Subscript si a (i:[])) =
+explodeExpr (Subscript si a [i]) =
   Untyped.Subscript si (explodeExpr a) (explodeExpr i)
 explodeExpr (Subscript si a (i:ir)) =
   explodeExpr (Subscript si (Subscript si a [i]) ir)
@@ -55,6 +55,7 @@ explodeExpr (Fn si (arg:args) b) =
   Untyped.Fn si (explodeBinding arg) (explodeExpr (Fn si args b))
 
 -- invalid, but can be handled anyway
+explodeExpr (Subscript _ a []) = explodeExpr a
 explodeExpr (Let _ [] b) = explodeExpr b
 explodeExpr (Let _ [LetPair si n e] b) =
   Untyped.Let si (explodeBinding n) (explodeExpr e) (explodeExpr b)

--- a/src/Oden/Infer.hs
+++ b/src/Oden/Infer.hs
@@ -156,13 +156,13 @@ infer expr = case expr of
   Untyped.Literal si (Untyped.String s) ->
     return (Core.Literal si (Core.String s) (TBasic si TString))
 
-  Untyped.Subscript si a is -> do
+  Untyped.Subscript si a i -> do
 -- This is wrong!!! It makes the result type of the subscripted
 -- slice be the slice type itself. We need to "unwrap" the slice somehow
     at <- infer a
-    tis <- mapM infer is
-    mapM_ (uni si (TBasic si TInt) . Core.typeOf) tis
-    return (Core.Subscript si at tis (Core.typeOf at))
+    ti <- infer i
+    uni (getSourceInfo ti) (Core.typeOf ti) (TBasic si TInt)
+    return (Core.Subscript si at ti (Core.typeOf at))
 
   Untyped.UnaryOp si o e -> do
     rt <- case o of

--- a/src/Oden/Infer.hs
+++ b/src/Oden/Infer.hs
@@ -156,6 +156,14 @@ infer expr = case expr of
   Untyped.Literal si (Untyped.String s) ->
     return (Core.Literal si (Core.String s) (TBasic si TString))
 
+  Untyped.Subscript si a is -> do
+-- This is wrong!!! It makes the result type of the subscripted
+-- slice be the slice type itself. We need to "unwrap" the slice somehow
+    at <- infer a
+    tis <- mapM infer is
+    mapM_ (uni si (TBasic si TInt) . Core.typeOf) tis
+    return (Core.Subscript si at tis (Core.typeOf at))
+
   Untyped.UnaryOp si o e -> do
     rt <- case o of
               Positive   -> return (TBasic si TInt)

--- a/src/Oden/Infer.hs
+++ b/src/Oden/Infer.hs
@@ -157,12 +157,12 @@ infer expr = case expr of
     return (Core.Literal si (Core.String s) (TBasic si TString))
 
   Untyped.Subscript si a i -> do
--- This is wrong!!! It makes the result type of the subscripted
--- slice be the slice type itself. We need to "unwrap" the slice somehow
     at <- infer a
     ti <- infer i
+    tv <- (fresh . getSourceInfo) i
+    uni si (Core.typeOf at) (TSlice si tv)
     uni (getSourceInfo ti) (Core.typeOf ti) (TBasic si TInt)
-    return (Core.Subscript si at ti (Core.typeOf at))
+    return (Core.Subscript si at ti tv)
 
   Untyped.UnaryOp si o e -> do
     rt <- case o of

--- a/src/Oden/Infer/Substitution.hs
+++ b/src/Oden/Infer/Substitution.hs
@@ -56,6 +56,7 @@ instance FTV (Core.Expr Type) where
 
 instance Substitutable (Core.Expr Type) where
   apply s (Core.Symbol si x t)                   = Core.Symbol si x (apply s t)
+  apply s (Core.Subscript si a is t)             = Core.Subscript si (apply s a) (apply s is) (apply s t)
   apply s (Core.UnaryOp si o e t)                = Core.UnaryOp si o (apply s e) (apply s t)
   apply s (Core.BinaryOp si o e1 e2 t)           = Core.BinaryOp si o (apply s e1) (apply s e2) (apply s t)
   apply s (Core.Application si f p t)            = Core.Application si (apply s f) (apply s p) (apply s t)

--- a/src/Oden/Parser.hs
+++ b/src/Oden/Parser.hs
@@ -140,7 +140,16 @@ unitExprOrTuple = do
     (f:s:r) -> return (Tuple si f s r)
 
 term :: Parser Expr
-term =
+term = do
+  si <- currentSourceInfo
+  arrayBase <- termNoArray
+  indices <- many $ (brackets expr >>= return)
+  case indices of
+    [] -> return arrayBase
+    is -> return (Subscript si arrayBase is)
+
+termNoArray :: Parser Expr
+termNoArray =
   try fn
   <|> if'
   <|> let'

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -46,6 +46,7 @@ instance Pretty Identifier where
 
 instance Pretty (Expr t) where
   pp (Symbol _ i _) = pp i
+  pp (Subscript _ a is _) = pp a <+> (hcat (map (brackets . pp) is))
   pp (UnaryOp _ op e _) = pp op <+> pp e
   pp (BinaryOp _ op e1 e2 _) = pp e1 <+> pp op <+> pp e2
   pp (Application _ f a _) = pp f <> text "(" <> pp a <> text ")"

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -46,7 +46,7 @@ instance Pretty Identifier where
 
 instance Pretty (Expr t) where
   pp (Symbol _ i _) = pp i
-  pp (Subscript _ a is _) = pp a <+> (hcat (map (brackets . pp) is))
+  pp (Subscript _ a i _) = pp a <> text "[" <> pp i <> text "]"
   pp (UnaryOp _ op e _) = pp op <+> pp e
   pp (BinaryOp _ op e1 e2 _) = pp e1 <+> pp op <+> pp e2
   pp (Application _ f a _) = pp f <> text "(" <> pp a <> text ")"

--- a/src/Oden/Syntax.hs
+++ b/src/Oden/Syntax.hs
@@ -11,6 +11,7 @@ data LetPair = LetPair SourceInfo Binding Expr
              deriving (Show, Eq, Ord)
 
 data Expr = Symbol SourceInfo Identifier
+          | Subscript SourceInfo Expr [Expr]
           | UnaryOp SourceInfo UnaryOperator Expr
           | BinaryOp SourceInfo BinaryOperator Expr Expr
           | Application SourceInfo Expr [Expr]

--- a/test/Oden/ParserSpec.hs
+++ b/test/Oden/ParserSpec.hs
@@ -212,6 +212,15 @@ spec = do
           Symbol (src 1 10) (Unqualified "z")
         ]
 
+    it "parses subscript" $
+      parseExpr "a[b]"
+      `shouldSucceedWith`
+      Subscript (src 1 1)
+        (Symbol (src 1 1) (Unqualified "a"))
+        [(Symbol (src 1 3) (Unqualified "b"))]
+
+
+
   describe "parseTopLevel" $ do
     it "parses type signature" $
       parseTopLevel "x :: int"


### PR DESCRIPTION
Added subscripts for slices to extract singular values:

```
package main

import fmt

main :: -> ()
main -> let one = []{1,2,3}
            two = []{one, one}
            three = []{"a", "b", "c"} in {
	fmt.Println(one[1])                          // 2
	fmt.Println(two[0][2] + 5)                   // 8
	fmt.Println(three[0] ++ " as in Albin")      // "a as in Albin"
}
```
