### PR TITLE
Added support for half-open subslices

### DIFF
--- a/src/Oden/Backend/Go.hs
+++ b/src/Oden/Backend/Go.hs
@@ -142,7 +142,9 @@ codegenExpr (Symbol _ i _) =
 codegenExpr (Subscript _ s i _) =
   codegenExpr s <> (brackets . codegenExpr) i
 codegenExpr (Subslice _ s i1 i2 _) =
-  codegenExpr s <> (brackets $ hcat $ punctuate (text ":") $ map codegenExpr [i1, i2])
+  codegenExpr s <> (brackets $ (maybe empty codegenExpr i1) <+>
+                               (text ":") <+>
+                               (maybe empty codegenExpr i2))
 codegenExpr (UnaryOp _ o e _) =
   parens (codegenUnaryOperator o <+> codegenExpr e)
 codegenExpr (BinaryOp _ o e1 e2 _) =

--- a/src/Oden/Compiler/Instantiate.hs
+++ b/src/Oden/Compiler/Instantiate.hs
@@ -93,10 +93,10 @@ instantiateExpr (Core.Subscript si s i t) =
   Core.Subscript si <$> instantiateExpr s
                     <*> instantiateExpr i
                     <*> replace t
-instantiateExpr (Core.Subslice si s i1 i2 t) =
+instantiateExpr (Core.Subslice si s maybei1 maybei2 t) =
   Core.Subslice si <$> instantiateExpr s
-                   <*> instantiateExpr i1
-                   <*> instantiateExpr i2
+                   <*> mapM instantiateExpr maybei1
+                   <*> mapM instantiateExpr maybei2
                    <*> replace t
 instantiateExpr (Core.UnaryOp si o e t) = 
   Core.UnaryOp si o <$> instantiateExpr e <*> replace t

--- a/src/Oden/Compiler/Monomorphization.hs
+++ b/src/Oden/Compiler/Monomorphization.hs
@@ -145,11 +145,11 @@ monomorph e@(Core.Subscript si s i _) = do
   ms <- monomorph s
   mi <- monomorph i
   return (Core.Subscript si ms mi mt)
-monomorph e@(Core.Subslice si s i1 i2 _) = do
+monomorph e@(Core.Subslice si s maybei1 maybei2 _) = do
   mt <- getMonoType e
   ms <- monomorph s
-  mi1 <- monomorph i1
-  mi2 <- monomorph i2
+  mi1 <- mapM monomorph maybei1
+  mi2 <- mapM monomorph maybei2
   return (Core.Subslice si ms mi1 mi2 mt)
 monomorph e@(Core.UnaryOp si o e1 _) = do
   mt <- getMonoType e

--- a/src/Oden/Compiler/Validation.hs
+++ b/src/Oden/Compiler/Validation.hs
@@ -37,10 +37,10 @@ validateExpr Symbol{} = return ()
 validateExpr (Subscript _ s i _) = do
   validateExpr s
   validateExpr i
-validateExpr (Subslice _ s i1 i2 _) = do
+validateExpr (Subslice _ s maybei1 maybei2 _) = do
   validateExpr s
-  validateExpr i1
-  validateExpr i2
+  mapM_ validateExpr maybei1
+  mapM_ validateExpr maybei2
 validateExpr (UnaryOp _ _ rhs _) =
   validateExpr rhs
 validateExpr (BinaryOp _ _ lhs rhs _) = do

--- a/src/Oden/Core.hs
+++ b/src/Oden/Core.hs
@@ -11,7 +11,7 @@ data Binding = Binding SourceInfo Name
 
 data Expr t = Symbol SourceInfo Identifier t
             | Subscript SourceInfo (Expr t) (Expr t) t
-            | Subslice SourceInfo (Expr t) (Expr t) (Expr t) t
+            | Subslice SourceInfo (Expr t) (Maybe (Expr t)) (Maybe (Expr t)) t
             | UnaryOp SourceInfo UnaryOperator (Expr t) t
             | BinaryOp SourceInfo BinaryOperator (Expr t) (Expr t) t
             | Application SourceInfo (Expr t) (Expr t) t

--- a/src/Oden/Core/Untyped.hs
+++ b/src/Oden/Core/Untyped.hs
@@ -10,7 +10,7 @@ data Binding = Binding SourceInfo Name
 
 data Expr = Symbol SourceInfo Identifier
           | Subscript SourceInfo Expr Expr
-          | Subslice SourceInfo Expr Expr Expr
+          | Subslice SourceInfo Expr (Maybe Expr) (Maybe Expr)
           | UnaryOp SourceInfo UnaryOperator Expr
           | BinaryOp SourceInfo BinaryOperator Expr Expr
           | Application SourceInfo Expr [Expr]

--- a/src/Oden/Explode.hs
+++ b/src/Oden/Explode.hs
@@ -23,10 +23,12 @@ explodeBinding :: Binding -> Untyped.Binding
 explodeBinding (Binding si name) = Untyped.Binding si name
 
 explodeExpr :: Expr -> Untyped.Expr
-explodeExpr (Subscript si es [Singular e]) =
-  Untyped.Subscript si (explodeExpr es) (explodeExpr e)
-explodeExpr (Subscript si es [Range e1 e2]) =
-  Untyped.Subslice si (explodeExpr es) (explodeExpr e1) (explodeExpr e2)
+explodeExpr (Subscript si es [sub]) =
+  case sub of
+    Singular e  -> Untyped.Subscript si (explodeExpr es) (explodeExpr e)
+    Range e1 e2 -> Untyped.Subslice si (explodeExpr es) (Just $ explodeExpr e1) (Just $ explodeExpr e2)
+    OpenStart e -> Untyped.Subslice si (explodeExpr es) Nothing (Just $ explodeExpr e)
+    OpenEnd e   -> Untyped.Subslice si (explodeExpr es) (Just $ explodeExpr e) Nothing
 explodeExpr (Subscript si es (i:ir)) =
   explodeExpr (Subscript si (Subscript si es [i]) ir)
 

--- a/src/Oden/Infer.hs
+++ b/src/Oden/Infer.hs
@@ -164,7 +164,7 @@ infer expr = case expr of
     uni (getSourceInfo it) (Core.typeOf it) (TBasic si TInt)
     return (Core.Subscript si st it tv)
 
-  Untyped.Subslice si s i1 i2 -> do
+  Untyped.Subslice si s (Just i1) (Just i2) -> do
     st <- infer s
     i1t <- infer i1
     i2t <- infer i2
@@ -172,7 +172,25 @@ infer expr = case expr of
     uni (getSourceInfo st) (Core.typeOf st) (TSlice (getSourceInfo s) tv)
     uni (getSourceInfo i1t) (Core.typeOf i1t) (TBasic si TInt)
     uni (getSourceInfo i2t) (Core.typeOf i2t) (TBasic si TInt)
-    return (Core.Subslice si st i1t i2t (TSlice si tv))
+    return (Core.Subslice si st (Just i1t) (Just i2t) (TSlice si tv))
+
+  Untyped.Subslice si s Nothing (Just i2) -> do
+    st <- infer s
+    i2t <- infer i2
+    tv <- fresh si
+    uni (getSourceInfo st) (Core.typeOf st) (TSlice (getSourceInfo s) tv)
+    uni (getSourceInfo i2t) (Core.typeOf i2t) (TBasic si TInt)
+    return (Core.Subslice si st Nothing (Just i2t) (TSlice si tv))
+
+  Untyped.Subslice si s (Just i1) Nothing -> do
+    st <- infer s
+    i1t <- infer i1
+    tv <- fresh si
+    uni (getSourceInfo st) (Core.typeOf st) (TSlice (getSourceInfo s) tv)
+    uni (getSourceInfo i1t) (Core.typeOf i1t) (TBasic si TInt)
+    return (Core.Subslice si st (Just i1t) Nothing (TSlice si tv))
+
+-- Untyped.Subslice si s Nothing Nothing -> should never happen
 
   Untyped.UnaryOp si o e -> do
     rt <- case o of

--- a/src/Oden/Infer/Substitution.hs
+++ b/src/Oden/Infer/Substitution.hs
@@ -57,7 +57,7 @@ instance FTV (Core.Expr Type) where
 instance Substitutable (Core.Expr Type) where
   apply s (Core.Symbol si x t)                   = Core.Symbol si x (apply s t)
   apply s (Core.Subscript si es i t)             = Core.Subscript si (apply s es) (apply s i) (apply s t)
-  apply s (Core.Subslice si es i1 i2 t)          = Core.Subslice si (apply s es) (apply s i1) (apply s i2) (apply s t)
+  apply s (Core.Subslice si es i1 i2 t)          = Core.Subslice si (apply s es) (fmap (apply s) i1) (fmap (apply s) i2) (apply s t)
   apply s (Core.UnaryOp si o e t)                = Core.UnaryOp si o (apply s e) (apply s t)
   apply s (Core.BinaryOp si o e1 e2 t)           = Core.BinaryOp si o (apply s e1) (apply s e2) (apply s t)
   apply s (Core.Application si f p t)            = Core.Application si (apply s f) (apply s p) (apply s t)

--- a/src/Oden/Parser.hs
+++ b/src/Oden/Parser.hs
@@ -140,8 +140,10 @@ unitExprOrTuple = do
     (f:s:r) -> return (Tuple si f s r)
 
 subscript :: Parser Subscript
-subscript = try range <|> simple
+subscript = try openStart <|> try range <|> try openEnd <|> simple
   where
+    openStart = OpenStart <$> (char ':' *> expr)
+    openEnd = OpenEnd <$> (expr <* char ':')
     range = Range <$> expr <*> (char ':' *> expr)
     simple = Singular <$> expr
 

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -47,7 +47,9 @@ instance Pretty Identifier where
 instance Pretty (Expr t) where
   pp (Symbol _ i _) = pp i
   pp (Subscript _ s i _) = pp s <> text "[" <> pp i <> text "]"
-  pp (Subslice _ s i1 i2 _) = pp s <> text "[" <> pp i1 <> text ":" <> pp i2 <> text "]"
+  pp (Subslice _ s maybei1 maybei2 _) = pp s <> (brackets $ (maybe empty pp maybei1) <+>
+                                                            text ":" <+>
+                                                            (maybe empty pp maybei2))
   pp (UnaryOp _ op e _) = pp op <+> pp e
   pp (BinaryOp _ op e1 e2 _) = pp e1 <+> pp op <+> pp e2
   pp (Application _ f a _) = pp f <> text "(" <> pp a <> text ")"

--- a/src/Oden/Syntax.hs
+++ b/src/Oden/Syntax.hs
@@ -25,6 +25,8 @@ data Expr = Symbol SourceInfo Identifier
           deriving (Show, Eq, Ord)
 
 data Subscript = Singular Expr
+               | OpenStart Expr
+               | OpenEnd Expr
                | Range Expr Expr
                deriving (Show, Eq, Ord)
 

--- a/test/Oden/ParserSpec.hs
+++ b/test/Oden/ParserSpec.hs
@@ -219,7 +219,7 @@ spec = do
         (Symbol (src 1 1) (Unqualified "a"))
         [(Singular (Symbol (src 1 3) (Unqualified "b")))]
 
-    it "parses sublices" $
+    it "parses closed sublices" $
       parseExpr "a[b:c]"
       `shouldSucceedWith`
       Subscript (src 1 1)
@@ -227,6 +227,22 @@ spec = do
         [(Range (Symbol (src 1 3) (Unqualified "b"))
                 (Symbol (src 1 5) (Unqualified "c")))]
 
+    it "parses subslices with open start" $
+      parseExpr "a[:c]"
+      `shouldSucceedWith`
+      Subscript (src 1 1)
+        (Symbol (src 1 1) (Unqualified "a"))
+        [OpenStart (Symbol (src 1 4) (Unqualified "c"))]
+
+    it "parses subslices with open ending" $
+      parseExpr "a[b:]"
+      `shouldSucceedWith`
+      Subscript (src 1 1)
+        (Symbol (src 1 1) (Unqualified "a"))
+        [OpenEnd (Symbol (src 1 3) (Unqualified "b"))]
+
+    it "fails on subslices with open start and end" $
+      shouldFail $ parseExpr "a[:]"
 
 
   describe "parseTopLevel" $ do


### PR DESCRIPTION
Subslices can now have open start `slice[:5]` or open end `slice[2:]`.

After parsing, subslices are exploded into

`Subslice Expr (Maybe Expr) (Maybe Expr)` (slice startindex endindex)

Parsing makes sure that the `Nothing Nothing` case never happens.

My lacking Haskell experience wonders if this is the right way to go. For example, there is a warning in Infer.hs that the `Nothing Nothing` case isn't handled. And a lot of places where all other cases just takes expressions (or list of expression), but the Subslice needs to handle Maybes.

Feedback is welcome! :-)