### PR TITLE
Added support for half-open subslices, second try

### DIFF
--- a/src/Oden/Backend/Go.hs
+++ b/src/Oden/Backend/Go.hs
@@ -136,13 +136,21 @@ codegenBinaryOperator Or = text "||"
 codegenUnaryOperator :: UnaryOperator -> Doc
 codegenUnaryOperator o = text (show o)
 
+codegenRange :: Range Mono.Type -> Doc
+codegenRange (Range e1 e2) =
+  brackets $ hcat $ punctuate (text ":") $ map codegenExpr [e1, e2]
+codegenRange (RangeTo e) =
+  brackets $ text ":" <+> codegenExpr e
+codegenRange (RangeFrom e) =
+  brackets $ codegenExpr e <+> (text ":")
+
 codegenExpr :: Expr Mono.Type -> Doc
 codegenExpr (Symbol _ i _) =
   codegenIdentifier i
 codegenExpr (Subscript _ s i _) =
   codegenExpr s <> (brackets . codegenExpr) i
-codegenExpr (Subslice _ s i1 i2 _) =
-  codegenExpr s <> (brackets $ hcat $ punctuate (text ":") $ map codegenExpr [i1, i2])
+codegenExpr (Subslice _ s r _) =
+  codegenExpr s <> codegenRange r
 codegenExpr (UnaryOp _ o e _) =
   parens (codegenUnaryOperator o <+> codegenExpr e)
 codegenExpr (BinaryOp _ o e1 e2 _) =

--- a/src/Oden/Compiler/Instantiate.hs
+++ b/src/Oden/Compiler/Instantiate.hs
@@ -93,11 +93,20 @@ instantiateExpr (Core.Subscript si s i t) =
   Core.Subscript si <$> instantiateExpr s
                     <*> instantiateExpr i
                     <*> replace t
-instantiateExpr (Core.Subslice si s i1 i2 t) =
+
+instantiateExpr (Core.Subslice si s (Core.Range e1 e2) t) =
   Core.Subslice si <$> instantiateExpr s
-                   <*> instantiateExpr i1
-                   <*> instantiateExpr i2
+                   <*> (Core.Range <$> (instantiateExpr e1) <*> (instantiateExpr e2))
                    <*> replace t
+instantiateExpr (Core.Subslice si s (Core.RangeTo e) t) =
+  Core.Subslice si <$> instantiateExpr s
+                   <*> (Core.RangeTo <$> (instantiateExpr e))
+                   <*> replace t
+instantiateExpr (Core.Subslice si s (Core.RangeFrom e) t) =
+  Core.Subslice si <$> instantiateExpr s
+                   <*> (Core.RangeFrom <$> (instantiateExpr e))
+                   <*> replace t
+
 instantiateExpr (Core.UnaryOp si o e t) = 
   Core.UnaryOp si o <$> instantiateExpr e <*> replace t
 instantiateExpr (Core.BinaryOp si o e1 e2 t) =

--- a/src/Oden/Compiler/Monomorphization.hs
+++ b/src/Oden/Compiler/Monomorphization.hs
@@ -156,12 +156,22 @@ monomorph e@(Core.Subscript si s i _) = do
   ms <- monomorph s
   mi <- monomorph i
   return (Core.Subscript si ms mi mt)
-monomorph e@(Core.Subslice si s i1 i2 _) = do
+monomorph e@(Core.Subslice si s (Core.Range e1 e2) _) = do
   mt <- getMonoType e
   ms <- monomorph s
-  mi1 <- monomorph i1
-  mi2 <- monomorph i2
-  return (Core.Subslice si ms mi1 mi2 mt)
+  me1 <- monomorph e1
+  me2 <- monomorph e2
+  return (Core.Subslice si ms (Core.Range me1 me2) mt)
+monomorph e@(Core.Subslice si s (Core.RangeTo i) _) = do
+  mt <- getMonoType e
+  ms <- monomorph s
+  mi <- monomorph i
+  return (Core.Subslice si ms (Core.RangeTo mi) mt)
+monomorph e@(Core.Subslice si s (Core.RangeFrom i) _) = do
+  mt <- getMonoType e
+  ms <- monomorph s
+  mi <- monomorph i
+  return (Core.Subslice si ms (Core.RangeFrom mi) mt)
 monomorph e@(Core.UnaryOp si o e1 _) = do
   mt <- getMonoType e
   me <- monomorph e1

--- a/src/Oden/Compiler/Validation.hs
+++ b/src/Oden/Compiler/Validation.hs
@@ -37,10 +37,9 @@ validateExpr Symbol{} = return ()
 validateExpr (Subscript _ s i _) = do
   validateExpr s
   validateExpr i
-validateExpr (Subslice _ s i1 i2 _) = do
+validateExpr (Subslice _ s r _) = do
   validateExpr s
-  validateExpr i1
-  validateExpr i2
+  validateRange r
 validateExpr (UnaryOp _ _ rhs _) =
   validateExpr rhs
 validateExpr (BinaryOp _ _ lhs rhs _) = do
@@ -80,6 +79,15 @@ validateExpr (Block _ exprs _) = do
   warnOnDiscarded expr = case typeOf expr of
     TUnit{} -> return ()
     _ -> throwError (ValueDiscarded expr)
+
+validateRange :: Range Type -> Validate()
+validateRange (Range e1 e2) = do
+  validateExpr e1
+  validateExpr e2
+validateRange (RangeTo e) =
+  validateExpr e
+validateRange (RangeFrom e) =
+  validateExpr e
 
 validatePackage :: Package -> Validate ()
 validatePackage (Package _ _ definitions) = validateSeq definitions

--- a/src/Oden/Core.hs
+++ b/src/Oden/Core.hs
@@ -11,7 +11,7 @@ data NameBinding = NameBinding SourceInfo Name
 
 data Expr t = Symbol SourceInfo Identifier t
             | Subscript SourceInfo (Expr t) (Expr t) t
-            | Subslice SourceInfo (Expr t) (Expr t) (Expr t) t
+            | Subslice SourceInfo (Expr t) (Range t) t
             | UnaryOp SourceInfo UnaryOperator (Expr t) t
             | BinaryOp SourceInfo BinaryOperator (Expr t) (Expr t) t
             | Application SourceInfo (Expr t) (Expr t) t
@@ -30,7 +30,7 @@ data Expr t = Symbol SourceInfo Identifier t
 instance HasSourceInfo (Expr t) where
   getSourceInfo (Symbol si _ _)                   = si
   getSourceInfo (Subscript si _ _ _)              = si
-  getSourceInfo (Subslice si _ _ _ _)             = si
+  getSourceInfo (Subslice si _ _ _)               = si
   getSourceInfo (UnaryOp si _ _ _)                = si
   getSourceInfo (BinaryOp si _ _ _ _)             = si
   getSourceInfo (Application si _ _ _)            = si
@@ -47,7 +47,7 @@ instance HasSourceInfo (Expr t) where
 
   setSourceInfo si (Symbol _ i t)                   = Symbol si i t
   setSourceInfo si (Subscript _ s i t)              = Subscript si s i t
-  setSourceInfo si (Subslice _ s i1 i2 t)           = Subslice si s i1 i2 t
+  setSourceInfo si (Subslice _ s r t)               = Subslice si s r t
   setSourceInfo si (UnaryOp _ o r t)                = UnaryOp si o r t
   setSourceInfo si (BinaryOp _ p l r t)             = BinaryOp si p l r t
   setSourceInfo si (Application _ f a t)            = Application si f a t
@@ -65,7 +65,7 @@ instance HasSourceInfo (Expr t) where
 typeOf :: Expr t -> t
 typeOf (Symbol _ _ t) = t
 typeOf (Subscript _ _ _ t) = t
-typeOf (Subslice _ _ _ _ t) = t
+typeOf (Subslice _ _ _ t) = t
 typeOf (UnaryOp _ _ _ t) = t
 typeOf (BinaryOp _ _ _ _ t) = t
 typeOf (Application _ _ _ t) = t
@@ -84,6 +84,11 @@ data Literal = Int Integer
              | Bool Bool
              | String String
              | Unit
+             deriving (Show, Eq, Ord)
+
+data Range t = Range (Expr t) (Expr t)
+             | RangeTo (Expr t)
+             | RangeFrom (Expr t)
              deriving (Show, Eq, Ord)
 
 type CanonicalExpr = (Scheme, Expr Type)

--- a/src/Oden/Core/Untyped.hs
+++ b/src/Oden/Core/Untyped.hs
@@ -10,7 +10,7 @@ data NameBinding = NameBinding SourceInfo Name
 
 data Expr = Symbol SourceInfo Identifier
           | Subscript SourceInfo Expr Expr
-          | Subslice SourceInfo Expr Expr Expr
+          | Subslice SourceInfo Expr Range
           | UnaryOp SourceInfo UnaryOperator Expr
           | BinaryOp SourceInfo BinaryOperator Expr Expr
           | Application SourceInfo Expr [Expr]
@@ -27,7 +27,7 @@ data Expr = Symbol SourceInfo Identifier
 instance HasSourceInfo Expr where
   getSourceInfo (Symbol si _)                   = si
   getSourceInfo (Subscript si _ _)              = si
-  getSourceInfo (Subslice si _ _ _)             = si
+  getSourceInfo (Subslice si _ _)               = si
   getSourceInfo (UnaryOp si _ _)                = si
   getSourceInfo (BinaryOp si _ _ _)             = si
   getSourceInfo (Application si _ _)            = si
@@ -42,7 +42,7 @@ instance HasSourceInfo Expr where
 
   setSourceInfo si (Symbol _ i)                   = Symbol si i
   setSourceInfo si (Subscript _ s i)              = Subscript si s i
-  setSourceInfo si (Subslice _ s i1 i2)           = Subslice si s i1 i2
+  setSourceInfo si (Subslice _ s r)               = Subslice si s r
   setSourceInfo si (UnaryOp _ p r)                = UnaryOp si p r
   setSourceInfo si (BinaryOp _ p l r)             = BinaryOp si p l r
   setSourceInfo si (Application _ f a)            = Application si f a
@@ -61,8 +61,13 @@ data Literal = Int Integer
              | Unit
              deriving (Show, Eq, Ord)
 
+data Range = Range Expr Expr
+           | RangeTo Expr
+           | RangeFrom Expr
+           deriving (Show, Eq, Ord)
+
 data Definition = Definition SourceInfo Name (Maybe TypeSignature) Expr
-                deriving (Show, Eq, Ord)
+                  deriving (Show, Eq, Ord)
 
 type PackageName = [Name]
 

--- a/src/Oden/Explode.hs
+++ b/src/Oden/Explode.hs
@@ -24,7 +24,11 @@ explodeExpr :: Expr -> Untyped.Expr
 explodeExpr (Subscript si es [Singular e]) =
   Untyped.Subscript si (explodeExpr es) (explodeExpr e)
 explodeExpr (Subscript si es [Range e1 e2]) =
-  Untyped.Subslice si (explodeExpr es) (explodeExpr e1) (explodeExpr e2)
+  Untyped.Subslice si (explodeExpr es) (Untyped.Range (explodeExpr e1) (explodeExpr e2))
+explodeExpr (Subscript si es [RangeTo e]) =
+  Untyped.Subslice si (explodeExpr es) (Untyped.RangeTo (explodeExpr e))
+explodeExpr (Subscript si es [RangeFrom e]) =
+  Untyped.Subslice si (explodeExpr es) (Untyped.RangeFrom (explodeExpr e))
 explodeExpr (Subscript si es (i:ir)) =
   explodeExpr (Subscript si (Subscript si es [i]) ir)
 

--- a/src/Oden/Infer.hs
+++ b/src/Oden/Infer.hs
@@ -222,15 +222,31 @@ infer expr = case expr of
     uni (getSourceInfo it) (Core.typeOf it) (TBasic si TInt)
     return (Core.Subscript si st it tv)
 
-  Untyped.Subslice si s i1 i2 -> do
+  Untyped.Subslice si s (Untyped.Range e1 e2) -> do
     st <- infer s
-    i1t <- infer i1
-    i2t <- infer i2
+    e1t <- infer e1
+    e2t <- infer e2
     tv <- fresh si
     uni (getSourceInfo st) (Core.typeOf st) (TSlice (getSourceInfo s) tv)
-    uni (getSourceInfo i1t) (Core.typeOf i1t) (TBasic si TInt)
-    uni (getSourceInfo i2t) (Core.typeOf i2t) (TBasic si TInt)
-    return (Core.Subslice si st i1t i2t (TSlice si tv))
+    uni (getSourceInfo e1t) (Core.typeOf e1t) (TBasic si TInt)
+    uni (getSourceInfo e2t) (Core.typeOf e2t) (TBasic si TInt)
+    return (Core.Subslice si st (Core.Range e1t e2t) (TSlice si tv))
+
+  Untyped.Subslice si s (Untyped.RangeTo e) -> do
+    st <- infer s
+    et <- infer e
+    tv <- fresh si
+    uni (getSourceInfo st) (Core.typeOf st) (TSlice (getSourceInfo s) tv)
+    uni (getSourceInfo et) (Core.typeOf et) (TBasic si TInt)
+    return (Core.Subslice si st (Core.RangeTo et) (TSlice si tv))
+
+  Untyped.Subslice si s (Untyped.RangeFrom e) -> do
+    st <- infer s
+    et <- infer e
+    tv <- fresh si
+    uni (getSourceInfo st) (Core.typeOf st) (TSlice (getSourceInfo s) tv)
+    uni (getSourceInfo et) (Core.typeOf et) (TBasic si TInt)
+    return (Core.Subslice si st (Core.RangeFrom et) (TSlice si tv))
 
   Untyped.UnaryOp si o e -> do
     rt <- case o of

--- a/src/Oden/Infer/Substitution.hs
+++ b/src/Oden/Infer/Substitution.hs
@@ -57,7 +57,9 @@ instance FTV (Core.Expr Type) where
 instance Substitutable (Core.Expr Type) where
   apply s (Core.Symbol si x t)                   = Core.Symbol si x (apply s t)
   apply s (Core.Subscript si es i t)             = Core.Subscript si (apply s es) (apply s i) (apply s t)
-  apply s (Core.Subslice si es i1 i2 t)          = Core.Subslice si (apply s es) (apply s i1) (apply s i2) (apply s t)
+  apply s (Core.Subslice si es (Range e1 e2) t)  = Core.Subslice si (apply s es) (Range (apply s e1) (apply s e2)) (apply s t)
+  apply s (Core.Subslice si es (RangeTo e) t)  = Core.Subslice si (apply s es) (RangeTo (apply s e)) (apply s t)
+  apply s (Core.Subslice si es (RangeFrom e) t)    = Core.Subslice si (apply s es) (RangeFrom (apply s e)) (apply s t)
   apply s (Core.UnaryOp si o e t)                = Core.UnaryOp si o (apply s e) (apply s t)
   apply s (Core.BinaryOp si o e1 e2 t)           = Core.BinaryOp si o (apply s e1) (apply s e2) (apply s t)
   apply s (Core.Application si f p t)            = Core.Application si (apply s f) (apply s p) (apply s t)

--- a/src/Oden/Parser.hs
+++ b/src/Oden/Parser.hs
@@ -143,10 +143,12 @@ unitExprOrTuple = do
     (f:s:r) -> return (Tuple si f s r)
 
 subscript :: Parser Subscript
-subscript = try range <|> simple
-  where
-    range = Range <$> expr <*> (char ':' *> expr)
-    simple = Singular <$> expr
+subscript = try openStart <|> try range <|> try openEnd <|> simple
+   where
+     openStart = RangeTo <$> (char ':' *> expr)
+     openEnd = RangeFrom <$> (expr <* char ':')
+     range = Range <$> expr <*> (char ':' *> expr)
+     simple = Singular <$> expr
 
 term :: Parser Expr
 term = do

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -48,7 +48,7 @@ instance Pretty Identifier where
 instance Pretty (Expr t) where
   pp (Symbol _ i _) = pp i
   pp (Subscript _ s i _) = pp s <> text "[" <> pp i <> text "]"
-  pp (Subslice _ s i1 i2 _) = pp s <> text "[" <> pp i1 <> text ":" <> pp i2 <> text "]"
+  pp (Subslice _ s r _) = pp s <> pp r
   pp (UnaryOp _ op e _) = pp op <+> pp e
   pp (BinaryOp _ op e1 e2 _) = pp e1 <+> pp op <+> pp e2
   pp (Application _ f a _) = pp f <> text "(" <> pp a <> text ")"
@@ -70,6 +70,11 @@ instance Pretty (Expr t) where
     text "[]" <> braces (hcat (punctuate (text ", ") (map pp es)))
   pp (Block _ es _) =
     braces (vcat (map pp es))
+
+instance Pretty (Range r) where
+  pp (Range e1 e2) = brackets $ pp e1 <+> (text ":") <+> pp e2
+  pp (RangeTo e) = brackets $ (text ":") <+> pp e
+  pp (RangeFrom e) = brackets $ pp e <+> (text ":")
 
 instance Pretty Poly.TVar where
   pp (Poly.TV s) = text ('#' : s)

--- a/src/Oden/Syntax.hs
+++ b/src/Oden/Syntax.hs
@@ -26,6 +26,8 @@ data Expr = Symbol SourceInfo Identifier
           deriving (Show, Eq, Ord)
 
 data Subscript = Singular Expr
+               | RangeTo Expr
+               | RangeFrom Expr
                | Range Expr Expr
                deriving (Show, Eq, Ord)
 

--- a/test/Oden/ParserSpec.hs
+++ b/test/Oden/ParserSpec.hs
@@ -213,14 +213,14 @@ spec = do
           Symbol (src 1 10) (Unqualified "z")
         ]
 
-    it "parses subscript" $
+    it "parses slice subscript" $
       parseExpr "a[b]"
       `shouldSucceedWith`
       Subscript (src 1 1)
         (Symbol (src 1 1) (Unqualified "a"))
         [Singular (Symbol (src 1 3) (Unqualified "b"))]
 
-    it "parses sublices" $
+    it "parses sublices with closed beginning and end" $
       parseExpr "a[b:c]"
       `shouldSucceedWith`
       Subscript (src 1 1)
@@ -228,7 +228,22 @@ spec = do
         [Range (Symbol (src 1 3) (Unqualified "b"))
                (Symbol (src 1 5) (Unqualified "c"))]
 
+    it "parses subslices with open start" $
+      parseExpr "a[:c]"
+      `shouldSucceedWith`
+      Subscript (src 1 1)
+        (Symbol (src 1 1) (Unqualified "a"))
+        [RangeTo (Symbol (src 1 4) (Unqualified "c"))]
 
+    it "parses subslices with open ending" $
+      parseExpr "a[b:]"
+      `shouldSucceedWith`
+      Subscript (src 1 1)
+        (Symbol (src 1 1) (Unqualified "a"))
+        [RangeFrom (Symbol (src 1 3) (Unqualified "b"))]
+
+    it "fails on subslices with open start and end" $
+      shouldFail $ parseExpr "a[:]"
 
   describe "parseTopLevel" $ do
     it "parses type signature" $


### PR DESCRIPTION
Subslices can now have open start `slice[:5]` or open end `slice[2:]`.

I went for making a new data type for the range, this time. Personally, it think it feels much better.