### PR TITLE
Added error for literal division by zero

### DIFF
--- a/oden.cabal
+++ b/oden.cabal
@@ -38,6 +38,7 @@ library
     Oden.Compiler.Monomorphization,
     Oden.Compiler.TypeEncoder
     Oden.Compiler.Validation,
+    Oden.Compiler.LiteralEval,
     Oden.Core,
     Oden.Core.Operator,
     Oden.Core.Untyped,

--- a/src/Oden/Compiler/LiteralEval.hs
+++ b/src/Oden/Compiler/LiteralEval.hs
@@ -6,8 +6,6 @@ import Oden.Core.Operator
 evaluate :: Expr t -> Maybe Literal
 evaluate Symbol{} = Nothing
 
--- Should probably be possible to evalute literal
--- expressions with literal slices and subslices as well.
 evaluate Subscript{} = Nothing
 evaluate Subslice{} = Nothing
 
@@ -64,8 +62,8 @@ evaluate (Literal _ l _) = Just l
 
 evaluate (If _ p e1 e2 _) = do
   (Bool b) <- evaluate p
-  if b then (evaluate e1)
-       else (evaluate e2)
+  if b then evaluate e1
+       else evaluate e2
 
 evaluate Slice{} = Nothing
 evaluate Tuple{} = Nothing

--- a/src/Oden/Compiler/LiteralEval.hs
+++ b/src/Oden/Compiler/LiteralEval.hs
@@ -1,0 +1,56 @@
+module Oden.Compiler.LiteralEval where
+
+import Oden.Core
+import Oden.Core.Operator
+
+evaluate :: Expr t -> Maybe Literal
+evaluate Symbol{} = Nothing
+
+-- Should probably be possible to evalute literal
+-- expressions with literal slices and subslices as well.
+evaluate Subscript{} = Nothing
+evaluate Subslice{} = Nothing
+
+-- We only do literal integer operations for now
+evaluate (UnaryOp _ Positive e _) = evaluate e
+evaluate (UnaryOp _ Negative e _) = do
+  (Int n) <- evaluate e
+  return $ Int (- n)
+evaluate (UnaryOp _ Not e _) = Nothing
+
+evaluate e@(BinaryOp _ Add _ _ _ ) = evaluateBinaryIntExpr e
+evaluate e@(BinaryOp _ Subtract _ _ _) = evaluateBinaryIntExpr e
+evaluate e@(BinaryOp _ Multiply _ _ _) = evaluateBinaryIntExpr e
+evaluate e@(BinaryOp _ Divide _ _ _) = evaluateBinaryIntExpr e
+evaluate BinaryOp{} = Nothing
+
+evaluate Application{} = Nothing
+evaluate NoArgApplication{} = Nothing
+evaluate ForeignFnApplication{} = Nothing
+
+evaluate Fn{} = Nothing
+evaluate NoArgFn{} = Nothing
+evaluate Let{} = Nothing
+
+evaluate RecordInitializer{} = Nothing
+evaluate RecordFieldAccess{} = Nothing
+evaluate PackageMemberAccess{} = Nothing
+
+evaluate (Literal _ l _) = Just l
+
+evaluate If{} = Nothing
+evaluate Slice{} = Nothing
+evaluate Tuple{} = Nothing
+evaluate Block{} = Nothing
+
+evaluateBinaryIntExpr :: Expr t -> Maybe Literal
+evaluateBinaryIntExpr (BinaryOp _ op e1 e2 _) = do
+  (Int n1) <- evaluate e1
+  (Int n2) <- evaluate e2
+  case op of
+    Add -> return $ Int (n1 + n2)
+    Subtract -> return $ Int (n1 - n2)
+    Multiply -> return $ Int (n1 * n2)
+    Divide -> return $ Int (n1 `div` n2)
+    _      -> Nothing
+evaluateBinaryIntExpr _ = Nothing

--- a/src/Oden/Compiler/Validation.hs
+++ b/src/Oden/Compiler/Validation.hs
@@ -21,6 +21,8 @@ data ValidationError = Redefinition SourceInfo Identifier
                      | ValueDiscarded (Expr Type)
                      | DuplicatedRecordFieldName SourceInfo Identifier
                      | DivisionByZero (Expr Type)
+                     | NegativeSliceIndex (Expr Type)
+                     | InvalidSubslice SourceInfo (Range Type)
                      deriving (Show, Eq, Ord)
 
 data ValidationWarning = ValidationWarning -- There's no warnings defined yet.
@@ -40,11 +42,33 @@ errorIfDefined name (Metadata si) = do
 withIdentifier :: Identifier -> Validate a -> Validate a
 withIdentifier = local . Set.insert
 
+validateSliceIndex :: Expr Type -> Validate ()
+validateSliceIndex e = do
+  validateExpr e
+  case evaluate e of
+    Just (Int n) | n < 0 -> throwError $ NegativeSliceIndex e
+    _ -> return ()
+
+
+validateRange :: Range Type -> Validate()
+validateRange r@(Range e1 e2) = do
+  validateSliceIndex e1
+  validateSliceIndex e2
+  case (evaluate e1, evaluate e2) of
+    (Just (Int v1), Just (Int v2)) |
+      v1 > v2 -> throwError $ InvalidSubslice (getSourceInfo e1) r
+    _ -> return ()
+validateRange (RangeTo e) =
+  validateSliceIndex e
+validateRange (RangeFrom e) =
+  validateSliceIndex e
+
+
 validateExpr :: Expr Type -> Validate ()
 validateExpr Symbol{} = return ()
 validateExpr (Subscript _ s i _) = do
   validateExpr s
-  validateExpr i
+  validateSliceIndex i
 validateExpr (Subslice _ s r _) = do
   validateExpr s
   validateRange r
@@ -97,14 +121,6 @@ validateExpr RecordInitializer{} = return ()
 validateExpr (RecordFieldAccess _ expr _ _) = validateExpr expr
 validateExpr PackageMemberAccess{} = return ()
 
-validateRange :: Range Type -> Validate()
-validateRange (Range e1 e2) = do
-  validateExpr e1
-  validateExpr e2
-validateRange (RangeTo e) =
-  validateExpr e
-validateRange (RangeFrom e) =
-  validateExpr e
 
 repeated :: [(Identifier, Type)] -> [(Identifier, Type)]
 repeated fields = snd (foldl check (Set.empty, []) fields)

--- a/src/Oden/Output/Compiler/Validation.hs
+++ b/src/Oden/Output/Compiler/Validation.hs
@@ -14,7 +14,9 @@ instance OdenOutput ValidationError where
   name Redefinition{}              = "Compiler.Validation.Redefinition"
   name ValueDiscarded{}            = "Compiler.Validation.ValueDiscarded"
   name DuplicatedRecordFieldName{} = "Compiler.Validation.DuplicatedRecordFieldName"
-  name DivisionByZero {}           = "Compiler.Validation.DivisionByZero"
+  name DivisionByZero{}            = "Compiler.Validation.DivisionByZero"
+  name NegativeSliceIndex{}        = "Compiler.Validation.NegativeSliceIndex"
+  name InvalidSubslice{}         = "Compiler.Validation.InvalidSubslice"
 
   header (Redefinition _ i) s =
     code s (pretty i) <+> text "is already defined"
@@ -24,18 +26,30 @@ instance OdenOutput ValidationError where
     <+> text "discarded"
   header (DuplicatedRecordFieldName _ n) _ =
     text "Duplicate struct field name" <+> pretty n
-  header (DivisionByZero e) s = text "Division by zero: "
-                                <+> code s (pretty e)
+  header (DivisionByZero e) s =
+    text "Division by zero: "
+    <+> code s (pretty e)
+  header (NegativeSliceIndex e) s =
+    text "Negative index: "
+    <+> code s (pretty e)
+  header (InvalidSubslice _ r) s =
+    text "Invalid subslice range "
+    <+> code s (pretty r)
+
 
   details Redefinition{} _              = text "Shadowing is not allowed"
   details ValueDiscarded{} _            = empty
   details DuplicatedRecordFieldName{} _ = empty
   details DivisionByZero{} _            = empty
+  details NegativeSliceIndex{} _        = text "Indices must be >= 0"
+  details InvalidSubslice{} _           = text "Ranges must go from smaller to bigger"
 
   sourceInfo (Redefinition si _) = Just si
   sourceInfo (ValueDiscarded e) = Just (getSourceInfo e)
   sourceInfo (DuplicatedRecordFieldName si _) = Just si
   sourceInfo (DivisionByZero e)  = Just (getSourceInfo e)
+  sourceInfo (NegativeSliceIndex e) = Just (getSourceInfo e)
+  sourceInfo (InvalidSubslice si _) = Just si
 
 instance OdenOutput ValidationWarning where
   outputType _ = Warning

--- a/src/Oden/Output/Compiler/Validation.hs
+++ b/src/Oden/Output/Compiler/Validation.hs
@@ -14,6 +14,7 @@ instance OdenOutput ValidationError where
   name Redefinition{}              = "Compiler.Validation.Redefinition"
   name ValueDiscarded{}            = "Compiler.Validation.ValueDiscarded"
   name DuplicatedRecordFieldName{} = "Compiler.Validation.DuplicatedRecordFieldName"
+  name DivisionByZero {}           = "Compiler.Validation.DivisionByZero"
 
   header (Redefinition _ i) s =
     code s (pretty i) <+> text "is already defined"
@@ -23,14 +24,18 @@ instance OdenOutput ValidationError where
     <+> text "discarded"
   header (DuplicatedRecordFieldName _ n) _ =
     text "Duplicate struct field name" <+> pretty n
+  header (DivisionByZero e) s = text "Division by zero: "
+                                <+> code s (pretty e)
 
   details Redefinition{} _              = text "Shadowing is not allowed"
   details ValueDiscarded{} _            = empty
   details DuplicatedRecordFieldName{} _ = empty
+  details DivisionByZero{} _            = empty
 
   sourceInfo (Redefinition si _) = Just si
   sourceInfo (ValueDiscarded e) = Just (getSourceInfo e)
   sourceInfo (DuplicatedRecordFieldName si _) = Just si
+  sourceInfo (DivisionByZero e)  = Just (getSourceInfo e)
 
 instance OdenOutput ValidationWarning where
   outputType _ = Warning

--- a/test/Oden/Compiler/LiteralEvalSpec.hs
+++ b/test/Oden/Compiler/LiteralEvalSpec.hs
@@ -1,0 +1,81 @@
+module Oden.Compiler.LiteralEvalSpec where
+
+import           Test.Hspec
+
+import           Oden.Compiler.LiteralEval
+import           Oden.Core
+import           Oden.Core.Operator
+import           Oden.Identifier
+import           Oden.Metadata
+import           Oden.Predefined
+import           Oden.SourceInfo
+import           Oden.Type.Polymorphic
+
+missing :: Metadata SourceInfo
+missing = Metadata Missing
+
+int :: Integer -> Expr Type
+int n = Literal missing (Int n) typeInt
+
+true :: Expr Type
+true = Literal missing (Bool True) typeBool
+
+false :: Expr Type
+false = Literal missing (Bool False) typeBool
+
+intExpr :: BinaryOperator -> Expr Type -> Expr Type -> Expr Type
+intExpr op l r = BinaryOp missing op l r typeInt
+
+boolExpr :: BinaryOperator -> Expr Type -> Expr Type -> Expr Type
+boolExpr op l r = BinaryOp missing op l r typeInt
+
+spec :: Spec
+spec =
+  describe "evaluate" $ do
+
+    it "evaluates integer literals" $
+      evaluate (int 5) `shouldBe` Just (Int 5)
+
+    it "evaluates addition" $
+      evaluate (intExpr Add (int 2) (int 3)) `shouldBe` Just (Int 5)
+
+    it "evaluates nested binary expressions: (3-2)*4 + 10/2" $
+      evaluate (intExpr Add 
+                        (intExpr Multiply
+                                 (intExpr Subtract 
+                                          (int 3)
+                                          (int 2))
+                                 (int 4))
+                        (intExpr Divide (int 10) (int 2)))
+      `shouldBe`
+      Just (Int 9)
+
+    it "evaluates boolean literals" $
+      evaluate true `shouldBe` Just (Bool True)
+
+    it "evaluates boolean expression: (true or false) and true" $
+      evaluate (boolExpr And (boolExpr Or true false) 
+                              true)
+      `shouldBe`
+      Just (Bool True)
+
+    it "evaluates integer comparison: (3 < 2) and (10 > 8)" $
+      evaluate (boolExpr And
+                        (boolExpr LessThan (int 3) (int 5))
+                        (boolExpr GreaterThan (int 10) (int 8)))
+      `shouldBe`
+      Just (Bool True)
+
+    it "evaluates if-expressions: if 2 == 3 then 1 else 2" $
+      evaluate (If missing (boolExpr Equals (int 2) (int 3))
+                           (int 1)
+                           (int 2)
+                   typeInt)
+      `shouldBe`
+      Just (Int 2)
+
+    it "evaluates expressions with variables to Nothing" $
+      evaluate (intExpr Add (int 5)
+                            (Symbol missing (Identifier "x") typeInt))
+      `shouldBe`
+      Nothing


### PR DESCRIPTION
Currently, expressions like `3 / (5 * (1 + 2 - 3))` will not generate a validation error in the Oden compiler, while the go compiler will detect it.

This commit only handles error for literal expressions with operators and if-statements. Expressions containing blocks, and/or slices are not considered, even though `3 / []{0}[0]` is a legal expression. (On the other hand, the Go compiler doesn't handle that expression either.)