### PR TITLE
Change top-level function and function expression syntax

### DIFF
--- a/regression-test/src/blocks/main.oden
+++ b/regression-test/src/blocks/main.oden
@@ -8,4 +8,4 @@ result = {
 }
 
 main :: -> ()
-main -> fmt.Println(result)
+main() = fmt.Println(result)

--- a/regression-test/src/comments/main.oden
+++ b/regression-test/src/comments/main.oden
@@ -5,4 +5,4 @@ import fmt
 /* this is a multiline comment */
 // this is a single line comment
 
-main -> /* they can be added here and there... */ fmt.Println("I've got nothing to say.") // it works here as well
+main() = /* they can be added here and there... */ fmt.Println("I've got nothing to say.") // it works here as well

--- a/regression-test/src/definitions/main.oden
+++ b/regression-test/src/definitions/main.oden
@@ -6,4 +6,4 @@ hello = "Hello"
 
 helloWorld = hello ++ ", world!"
 
-main -> fmt.Println(helloWorld)
+main() = fmt.Println(helloWorld)

--- a/regression-test/src/factorial/main.oden
+++ b/regression-test/src/factorial/main.oden
@@ -2,6 +2,6 @@ package factorial/main
 
 import fmt
 
-factorial n -> if n < 2 then 1 else n * factorial(n - 1)
+factorial(n) = if n < 2 then 1 else n * factorial(n - 1)
 
-main -> fmt.Println(factorial(5))
+main() = fmt.Println(factorial(5))

--- a/regression-test/src/fibonacci/main.oden
+++ b/regression-test/src/fibonacci/main.oden
@@ -2,10 +2,10 @@ package fibonacci/main
 
 import fmt
 
-fib n -> if n == 1 then 0 else {
+fib(n) = if n == 1 then 0 else {
   if n == 2 then 1 else {
     fib(n - 1) + fib(n - 2)
   }
 }
 
-main -> fmt.Println(fib(10))
+main() = fmt.Println(fib(10))

--- a/regression-test/src/higherorder/main.oden
+++ b/regression-test/src/higherorder/main.oden
@@ -2,8 +2,8 @@ package higherorder/main
 
 import fmt
 
-identity x -> x
+identity(x) = x
 
-applyTo1 x -> x(1)
+applyTo1(x) = x(1)
 
-main -> fmt.Println((identity(applyTo1))(fn x -> x * 2))
+main() = fmt.Println((identity(applyTo1))((x) -> x * 2))

--- a/regression-test/src/let/main.oden
+++ b/regression-test/src/let/main.oden
@@ -2,4 +2,4 @@ package let/main
 
 import fmt
 
-main -> fmt.Println(let name = "Foo" in name ++ "!")
+main() = fmt.Println(let name = "Foo" in name ++ "!")

--- a/regression-test/src/letpoly/main.oden
+++ b/regression-test/src/letpoly/main.oden
@@ -2,6 +2,6 @@ package letpoly/main
 
 import fmt
 
-identity x -> x
+identity(x) = x
 
-main -> fmt.Println(let id = identity(identity) in id("a"))
+main() = fmt.Println(let id = identity(identity) in id("a"))

--- a/regression-test/src/logic/main.oden
+++ b/regression-test/src/logic/main.oden
@@ -2,4 +2,4 @@ package logic/main
 
 import fmt
 
-main -> fmt.Println(if !(true && false) || false then "yey" else "ney")
+main() = fmt.Println(if !(true && false) || false then "yey" else "ney")

--- a/regression-test/src/main.oden
+++ b/regression-test/src/main.oden
@@ -4,9 +4,9 @@ package main
 // import declaration
 import fmt
 
-identityString x -> "" ++ x
+identityString(x) = "" ++ x
 
 result = identityString("Hello") ++ ", world!"
 
 // main function definition, must have type (-> unit)
-main -> fmt.Println(result)
+main() = fmt.Println(result)

--- a/regression-test/src/numbers/main.oden
+++ b/regression-test/src/numbers/main.oden
@@ -2,8 +2,8 @@ package numbers/main
 
 import fmt
 
-plus x y -> x + y
+plus(x, y) = x + y
 
 plus1 = plus(1)
 
-main -> fmt.Println(plus1(plus1(-10)))
+main() = fmt.Println(plus1(plus1(-10)))

--- a/regression-test/src/pair/main.oden
+++ b/regression-test/src/pair/main.oden
@@ -2,10 +2,10 @@ package pair/main
 
 import fmt
 
-pair x y f -> f(x, y)
+pair(x, y, f) = f(x, y)
 
-first p -> p(fn x y -> x)
+first(p) = p((x, y) -> x)
 
 p = pair("a", "b")
 
-main -> fmt.Println(first(p))
+main() = fmt.Println(first(p))

--- a/regression-test/src/pairlet/main.oden
+++ b/regression-test/src/pairlet/main.oden
@@ -2,10 +2,10 @@ package pairlet/main
 
 import fmt
 
-pair x y f -> f(x, y)
+pair(x, y, f) = f(x, y)
 
-first p -> p(fn x y -> x)
+first(p) = p((x, y) -> x)
 
-main -> {
+main() = {
   fmt.Println(let p = pair("a", 1) in first(p))
 }

--- a/regression-test/src/slices/main.oden
+++ b/regression-test/src/slices/main.oden
@@ -3,6 +3,6 @@ package slices/main
 import fmt
 
 main :: -> ()
-main -> let x = -200 in {
+main() = let x = -200 in {
   fmt.Println(-x, []{"OK"})
 }

--- a/regression-test/src/tuples/main.oden
+++ b/regression-test/src/tuples/main.oden
@@ -8,10 +8,10 @@ stuff :: (int, (), string)
 stuff = (1, nothing, "yey")
 
 pair :: #a -> #b -> (#a, #b)
-pair x y -> (x, y)
+pair(x, y) = (x, y)
 
 main :: -> ()
-main -> {
+main() = {
   fmt.Println(stuff)
 
   if (1, 2, 3) == (1, 2, 3) then {

--- a/regression-test/src/typealias.oden
+++ b/regression-test/src/typealias.oden
@@ -6,14 +6,14 @@ import fmt
 type IntPair = (int -> int -> int) -> int
 
 pair :: int -> int -> IntPair
-pair x y f -> f(x, y)
+pair(x, y, f) = f(x, y)
 
 first :: IntPair -> int
-first p -> p(fn x y -> x)
+first(p) = p((x, y) -> x)
 
 p :: IntPair
 p = pair(1, 2)
 
-main -> fmt.Println(first(p))
+main() = fmt.Println(first(p))
 
 

--- a/regression-test/src/typesig/main.oden
+++ b/regression-test/src/typesig/main.oden
@@ -2,18 +2,18 @@ package typesig/main
 
 import fmt
 
-identityNoTypeSig x -> x
+identityNoTypeSig(x) = x
 
 identityImplicit :: #a -> #a
-identityImplicit x -> x
+identityImplicit(x) = x
 
 identityExplicit :: forall #a. #a -> #a
-identityExplicit x -> x
+identityExplicit(x) = x
 
 theMessage :: string
 theMessage = "Type signatures work!"
 
-main -> fmt.Println(
+main() = fmt.Println(
   identityExplicit(
     identityImplicit(
       identityNoTypeSig(theMessage))))

--- a/regression-test/src/unicode/main.oden
+++ b/regression-test/src/unicode/main.oden
@@ -2,6 +2,6 @@ package unicode/main
 
 import fmt
 
-main -> {
+main() = {
   fmt.Println("As a [Swede], \229äö is what I want to write. \\\\ \"oh yeah\"")
 }

--- a/regression-test/src/unit/main.oden
+++ b/regression-test/src/unit/main.oden
@@ -4,4 +4,4 @@ import fmt
 
 testing = ()
 
-main -> fmt.Println("wtf...")
+main() = fmt.Println("wtf...")

--- a/src/Oden/Lexer.hs
+++ b/src/Oden/Lexer.hs
@@ -102,6 +102,9 @@ brackets = Tok.brackets lexer
 rArrow :: Parser ()
 rArrow = reservedOp "->"
 
+equals :: Parser ()
+equals = reservedOp "="
+
 packageName :: Parser [String]
 packageName = part `sepBy` char '/'
   where

--- a/test/Oden/ParserSpec.hs
+++ b/test/Oden/ParserSpec.hs
@@ -44,20 +44,20 @@ spec = do
       Literal (src 1 1) (String "foo bar 123")
 
     it "parses fn expression" $
-      parseExpr "fn x -> x"
+      parseExpr "(x) -> x"
       `shouldSucceedWith`
-      Fn (src 1 1) [NameBinding (src 1 4) "x"] (Symbol (src 1 9) (Unqualified "x"))
+      Fn (src 1 1) [NameBinding (src 1 2) "x"] (Symbol (src 1 8) (Unqualified "x"))
 
     it "parses multi-arg fn expression" $
-      parseExpr "fn x y z -> x"
+      parseExpr "(x, y, z) -> x"
       `shouldSucceedWith`
       Fn
       (src 1 1)
-      [NameBinding (src 1 4) "x", NameBinding (src 1 6) "y", NameBinding (src 1 8) "z"]
-      (Symbol (src 1 13) (Unqualified "x"))
+      [NameBinding (src 1 2) "x", NameBinding (src 1 5) "y", NameBinding (src 1 8) "z"]
+      (Symbol (src 1 14) (Unqualified "x"))
 
     it "parses no-arg fn expression" $
-      parseExpr "fn -> x"
+      parseExpr "() -> x"
       `shouldSucceedWith`
       Fn (src 1 1) [] (Symbol (src 1 7) (Unqualified "x"))
 
@@ -179,12 +179,12 @@ spec = do
       [Symbol (src 1 3) (Unqualified "y")]
 
     it "parses single-arg fn application" $
-      parseExpr "(fn x -> x)(y)"
+      parseExpr "((x) -> x)(y)"
       `shouldSucceedWith`
       Application
       (src 1 1)
-      (Fn (src 1 2) [NameBinding (src 1 5) "x"] (Symbol (src 1 10) (Unqualified "x")))
-      [Symbol (src 1 13) (Unqualified "y")]
+      (Fn (src 1 2) [NameBinding (src 1 3) "x"] (Symbol (src 1 9) (Unqualified "x")))
+      [Symbol (src 1 12) (Unqualified "y")]
 
     it "ignores whitespace" $
       parseExpr "x(   \n\n y \r\n\t   )"
@@ -343,26 +343,26 @@ spec = do
       ValueDefinition (src 1 1) "x" (Symbol (src 1 5) (Unqualified "y"))
 
     it "parses fn definition" $
-      parseTopLevel "f = fn x -> x"
+      parseTopLevel "f = (x) -> x"
       `shouldSucceedWith`
-      ValueDefinition (src 1 1) "f" (Fn (src 1 5) [NameBinding (src 1 8) "x"] (Symbol (src 1 13) (Unqualified "x")))
+      ValueDefinition (src 1 1) "f" (Fn (src 1 5) [NameBinding (src 1 6) "x"] (Symbol (src 1 12) (Unqualified "x")))
 
     it "parses short-hand fn definition" $
-      parseTopLevel "f x -> x"
+      parseTopLevel "f(x) = x"
       `shouldSucceedWith`
       FnDefinition (src 1 1) "f" [NameBinding (src 1 3) "x"] (Symbol (src 1 8) (Unqualified "x"))
 
     it "parses short-hand no-arg fn definition" $
-      parseTopLevel "side-effect -> x"
+      parseTopLevel "sideEffect() = x"
       `shouldSucceedWith`
-      FnDefinition (src 1 1) "side-effect" [] (Symbol (src 1 16) (Unqualified "x"))
+      FnDefinition (src 1 1) "sideEffect" [] (Symbol (src 1 16) (Unqualified "x"))
 
     it "parses short-hand multi-arg fn definition" $
-      parseTopLevel "f x y z -> x"
+      parseTopLevel "f(x, y, z) = x"
       `shouldSucceedWith`
       FnDefinition (src 1 1) "f"
-      [NameBinding (src 1 3) "x", NameBinding (src 1 5) "y", NameBinding (src 1 7) "z"]
-      (Symbol (src 1 12) (Unqualified "x"))
+      [NameBinding (src 1 3) "x", NameBinding (src 1 6) "y", NameBinding (src 1 9) "z"]
+      (Symbol (src 1 14) (Unqualified "x"))
 
   describe "parsePackage" $ do
     it "parses package declaration" $


### PR DESCRIPTION
This change makes top-level function definition syntax closer to how functions are applied. It's inspired by the standard mathematical notation, which is [how it's written in in Julia](http://docs.julialang.org/en/release-0.4/manual/functions/) for example.

**Before:**
```
f x y z -> x(y, z)
```
**After:**
```
f(x, y, z) = x(y, z)
```

Another change is how you write function expressions (anonymous functions). Removing the `fn` keyword and only utilizing the parenthesis and the right arrow `->` to distinguish a function expression gives us the following.

**Before:**
```
f = fn x y z -> x(y, z)
```

**After:**
```
f = (x, y, z) -> x(y, z)
```

I think this reads much better and I really like that top-level value definitions and function definitions share the `<name> ... = <expr>` structure.


The parser is still restrictive when it comes to function application, demanding a symbol or a parenthesized expression as the function to apply:

```
((x, y, z) -> x(y, z))(add, 1, 2)
```

Feedback is welcome! I want to get some input on this at it breaks basically all existing Oden programs. :bomb: 