### PR TITLE
Mapping multiple return values in Go to tuples in Oden

### DIFF
--- a/src/Oden/Backend/Go.hs
+++ b/src/Oden/Backend/Go.hs
@@ -205,7 +205,7 @@ codegenRawUncurredFnApplication f ps =
       return $ fc <> parens (hcat (punctuate (comma <+> space) pc))
 
 -- | Generates an anonymous function that will take arguments
--- | of the specified types and return a containing those values
+-- | of the specified types and return a tuple containing those values
 codegenToTupleWrapper :: Mono.Type -> Mono.Type -> [Mono.Type] -> Codegen Doc
 codegenToTupleWrapper t1 t2 tr =
   let

--- a/src/Oden/Backend/Go.hs
+++ b/src/Oden/Backend/Go.hs
@@ -130,10 +130,14 @@ codegenType (Mono.TFn _ d r) = do
 codegenType (Mono.TSlice _ t) = do
   tc <- codegenType t
   return $ text "[]" <> tc
-codegenType (Mono.TUncurriedFn _ as r) = do
+codegenType (Mono.TUncurriedFn _ as [r]) = do
   as' <- mapM codegenType as
   rc <- codegenType r
   return $ func empty (hcat (punctuate (comma <+> space) as')) rc empty
+codegenType (Mono.TUncurriedFn _ as rs) = do
+  as' <- mapM codegenType as
+  rcs <- mapM codegenType rs
+  return $ func empty (hcat (punctuate (comma <+> space) as')) (braces (hcat (punctuate (text ",") rcs))) empty
 codegenType (Mono.TVariadicFn _ as v r) = do
   as' <- mapM codegenType as
   vc <- codegenType v

--- a/src/Oden/Compiler/Instantiate.hs
+++ b/src/Oden/Compiler/Instantiate.hs
@@ -28,7 +28,7 @@ monoToPoly (Mono.TTuple si f s r) = Poly.TTuple si (monoToPoly f) (monoToPoly s)
 monoToPoly (Mono.TCon si d r) = Poly.TCon si (monoToPoly d) (monoToPoly r)
 monoToPoly (Mono.TNoArgFn si f) = Poly.TNoArgFn si (monoToPoly f)
 monoToPoly (Mono.TFn si f p) = Poly.TFn si (monoToPoly f) (monoToPoly p)
-monoToPoly (Mono.TUncurriedFn si as r) = Poly.TUncurriedFn si (map monoToPoly as) [monoToPoly r]
+monoToPoly (Mono.TUncurriedFn si as r) = Poly.TUncurriedFn si (map monoToPoly as) (map monoToPoly r)
 monoToPoly (Mono.TVariadicFn si as v r) = Poly.TVariadicFn si (map monoToPoly as) (monoToPoly v) (monoToPoly r)
 monoToPoly (Mono.TSlice si t) = Poly.TSlice si (monoToPoly t)
 monoToPoly (Mono.TStruct si fs) = Poly.TStruct si (map fieldMonoToPoly fs)
@@ -52,10 +52,10 @@ getSubstitutions (Poly.TFn _ pf pp) (Mono.TFn _ mf mp) = do
   ps <- getSubstitutions pp mp
   return (fs `mappend` ps)
 getSubstitutions (Poly.TVar _ v) mono = Right (Map.singleton v (monoToPoly mono))
-getSubstitutions (Poly.TUncurriedFn _ pas (pr:_)) (Mono.TUncurriedFn _ mas mr) = do
+getSubstitutions (Poly.TUncurriedFn _ pas prs) (Mono.TUncurriedFn _ mas mrs) = do
   as <- zipWithM getSubstitutions pas mas
-  r <- getSubstitutions pr mr
-  return (foldl mappend r as)
+  rs <- zipWithM getSubstitutions prs mrs
+  return (mconcat (rs ++ as))
 getSubstitutions (Poly.TVariadicFn _ pas pv pr) (Mono.TVariadicFn _ mas mv mr) = do
   as <- zipWithM getSubstitutions pas mas
   r <- getSubstitutions pr mr

--- a/src/Oden/Compiler/Instantiate.hs
+++ b/src/Oden/Compiler/Instantiate.hs
@@ -29,7 +29,7 @@ monoToPoly (Mono.TCon si d r) = Poly.TCon si (monoToPoly d) (monoToPoly r)
 monoToPoly (Mono.TNoArgFn si f) = Poly.TNoArgFn si (monoToPoly f)
 monoToPoly (Mono.TFn si f p) = Poly.TFn si (monoToPoly f) (monoToPoly p)
 monoToPoly (Mono.TUncurriedFn si as r) = Poly.TUncurriedFn si (map monoToPoly as) (map monoToPoly r)
-monoToPoly (Mono.TVariadicFn si as v r) = Poly.TVariadicFn si (map monoToPoly as) (monoToPoly v) (monoToPoly r)
+monoToPoly (Mono.TVariadicFn si as v r) = Poly.TVariadicFn si (map monoToPoly as) (monoToPoly v) (map monoToPoly r)
 monoToPoly (Mono.TSlice si t) = Poly.TSlice si (monoToPoly t)
 monoToPoly (Mono.TStruct si fs) = Poly.TStruct si (map fieldMonoToPoly fs)
   where fieldMonoToPoly (Mono.TStructField si' n mt) =
@@ -56,11 +56,11 @@ getSubstitutions (Poly.TUncurriedFn _ pas prs) (Mono.TUncurriedFn _ mas mrs) = d
   as <- zipWithM getSubstitutions pas mas
   rs <- zipWithM getSubstitutions prs mrs
   return (mconcat (rs ++ as))
-getSubstitutions (Poly.TVariadicFn _ pas pv pr) (Mono.TVariadicFn _ mas mv mr) = do
+getSubstitutions (Poly.TVariadicFn _ pas pv prs) (Mono.TVariadicFn _ mas mv mrs) = do
   as <- zipWithM getSubstitutions pas mas
-  r <- getSubstitutions pr mr
+  rs <- zipWithM getSubstitutions prs mrs
   v <- getSubstitutions pv mv
-  return (foldl mappend r (v:as))
+  return (mconcat (v:(as ++ rs)))
 getSubstitutions (Poly.TTuple _ pf ps pr) (Mono.TTuple _ mf ms mr) = do
   f <- getSubstitutions pf mf
   s <- getSubstitutions ps ms
@@ -87,7 +87,7 @@ replace (Poly.TFn si ft pt) = Poly.TFn si <$> replace ft <*> replace pt
 replace (Poly.TUncurriedFn si ft pt) =
   Poly.TUncurriedFn si <$> mapM replace ft <*> mapM replace pt
 replace (Poly.TVariadicFn si ft vt pt) =
-  Poly.TVariadicFn si <$> mapM replace ft <*> replace vt <*> replace pt
+  Poly.TVariadicFn si <$> mapM replace ft <*> replace vt <*> mapM replace pt
 replace (Poly.TSlice si t) = Poly.TSlice si <$> replace t
 replace (Poly.TStruct si fs) = Poly.TStruct si <$> mapM replaceField fs
   where replaceField (Poly.TStructField si' n t) =

--- a/src/Oden/Compiler/TypeEncoder.hs
+++ b/src/Oden/Compiler/TypeEncoder.hs
@@ -68,13 +68,16 @@ writeType (Mono.TUncurriedFn si as rs) = do
     (r1:r2:rt) -> withIncreasedLevel $ writeType (Mono.TTuple si r1 r2 rt)
   where
   writeArg a t = a >> withIncreasedLevel (writeType t) >> paddedTo
-writeType (Mono.TVariadicFn _ as v r) = do
+writeType (Mono.TVariadicFn si as v rs) = do
   foldl writeArg (return ()) as
   tell "variadic"
   pad
   withIncreasedLevel (writeType v)
   paddedTo
-  withIncreasedLevel (writeType r)
+  case rs of
+    [] -> undefined
+    [r] -> withIncreasedLevel (writeType r)
+    (r1:r2:rt) -> withIncreasedLevel $ writeType (Mono.TTuple si r1 r2 rt)
   where
   writeArg a t = a >> withIncreasedLevel (writeType t) >> paddedTo
 writeType (Mono.TSlice _ t) = do

--- a/src/Oden/Compiler/TypeEncoder.hs
+++ b/src/Oden/Compiler/TypeEncoder.hs
@@ -60,9 +60,12 @@ writeType (Mono.TFn _ tl tr) = do
   withIncreasedLevel (writeType tl)
   paddedTo
   withIncreasedLevel (writeType tr)
-writeType (Mono.TUncurriedFn _ as r) = do
+writeType (Mono.TUncurriedFn si as rs) = do
   foldl writeArg (return ()) as
-  withIncreasedLevel (writeType r)
+  case rs of
+    [] -> undefined
+    [r] -> withIncreasedLevel (writeType r)
+    (r1:r2:rt) -> withIncreasedLevel $ writeType (Mono.TTuple si r1 r2 rt)
   where
   writeArg a t = a >> withIncreasedLevel (writeType t) >> paddedTo
 writeType (Mono.TVariadicFn _ as v r) = do

--- a/src/Oden/Go.hs
+++ b/src/Oden/Go.hs
@@ -11,7 +11,6 @@ module Oden.Go (
   getPackageDefinitions
 ) where
 
-
 import qualified Oden.Core                  as Core
 import           Oden.Go.Types              as G
 import           Oden.Identifier
@@ -129,14 +128,11 @@ convertType Interface{} = Right $ Poly.TAny Missing
 convertType (Signature _ (Just _) _ _) = Left "Methods (functions with receivers)"
 convertType (Signature False Nothing args []) = do
   as <- mapM convertType args
-  Right (Poly.TUncurriedFn Missing as (Poly.TUnit Missing))
-convertType (Signature False Nothing args [ret]) = do
+  Right (Poly.TUncurriedFn Missing as [Poly.TUnit Missing])
+convertType (Signature False Nothing args ret) = do
   as <- mapM convertType args
-  r <- convertType ret
+  r <- mapM convertType ret
   Right (Poly.TUncurriedFn Missing as r)
-convertType (Signature False Nothing args _) = do
-  as <- mapM convertType args
-  Right (Poly.TUncurriedFn Missing as (Poly.TUnit Missing))
 convertType (Signature True Nothing [] []) = Left "Variadic functions with no arguments"
 convertType (Signature True Nothing args []) = do
   as <- mapM convertType (init args)

--- a/src/Oden/Go.hs
+++ b/src/Oden/Go.hs
@@ -131,22 +131,18 @@ convertType (Signature False Nothing args []) = do
   Right (Poly.TUncurriedFn Missing as [Poly.TUnit Missing])
 convertType (Signature False Nothing args ret) = do
   as <- mapM convertType args
-  r <- mapM convertType ret
-  Right (Poly.TUncurriedFn Missing as r)
+  rs <- mapM convertType ret
+  Right (Poly.TUncurriedFn Missing as rs)
 convertType (Signature True Nothing [] []) = Left "Variadic functions with no arguments"
 convertType (Signature True Nothing args []) = do
   as <- mapM convertType (init args)
   v <- convertType (last args)
-  Right (Poly.TVariadicFn Missing as v (Poly.TUnit Missing))
-convertType (Signature True Nothing args [ret]) = do
+  Right (Poly.TVariadicFn Missing as v [Poly.TUnit Missing])
+convertType (Signature True Nothing args ret) = do
   as <- mapM convertType (init args)
   v <- convertType (last args)
-  r <- convertType ret
-  Right (Poly.TVariadicFn Missing as v r)
-convertType (Signature True Nothing args _) = do
-  as <- mapM convertType (init args)
-  v <- convertType (last args)
-  Right (Poly.TVariadicFn Missing as v (Poly.TUnit Missing))
+  rs <- mapM convertType ret
+  Right (Poly.TVariadicFn Missing as v rs)
 -- convertType (Signature _ Nothing _ _) = Left "Functions with multiple return values"
 convertType (Named pkgName n (Struct fields)) = do
   fields' <- mapM convertField fields

--- a/src/Oden/Infer.hs
+++ b/src/Oden/Infer.hs
@@ -313,39 +313,26 @@ infer expr = case expr of
     tf <- infer f
     return (Core.NoArgFn si tf (TNoArgFn si (Core.typeOf tf)))
 
-  Untyped.Application si f [] -> do
-    tv <- fresh si
-    tf <- infer f
-    case Core.typeOf tf of
-      t@(TUncurriedFn _ _ [_]) -> do
-        uni (getSourceInfo tf) t (TUncurriedFn (getSourceInfo tf) [] [tv])
-        return (Core.UncurriedFnApplication si tf [] tv)
-      TUncurriedFn si _ (r1:r2:rs) -> do
-        -- Functions with multipe return values are really returning a
-        -- slice when executed
-        uni (getSourceInfo tf) (TUncurriedFn (getSourceInfo tf) [] [TTuple si r1 r2 rs])
-                               (TUncurriedFn (getSourceInfo tf) [] [tv])
-        return (Core.UncurriedFnApplication si tf [] tv)
-      -- No-param application of variadic function is automatically transformed
-      -- to application of empty slice.
-      t@(TVariadicFn _ [] variadicArg _) -> do
-        uni (getSourceInfo tf) t (TVariadicFn (getSourceInfo tf) [] variadicArg tv)
-        return (Core.UncurriedFnApplication si tf [Core.Slice (getSourceInfo variadicArg) [] variadicArg] tv)
-      TVariadicFn _ nonVariadicArgs _ _ ->
-        throwError (ArgumentCountMismatch tf nonVariadicArgs [])
-      t -> do
-        uni (getSourceInfo tf) t (TNoArgFn (getSourceInfo tf) tv)
-        return (Core.NoArgApplication si tf tv)
-
   Untyped.Application si f ps -> do
     tf <- infer f
     case Core.typeOf tf of
-      t@TUncurriedFn{} -> do
+
+      -- Uncurried non-variadic functions with a single return value
+      t@(TUncurriedFn _ _ [_]) -> do
         tv <- fresh (getSourceInfo t)
         tps <- mapM infer ps
-        -- TODO: MULTIVALUE
         uni (getSourceInfo tf) t (TUncurriedFn si (map Core.typeOf tps) [tv])
         return (Core.UncurriedFnApplication si tf tps tv)
+
+      -- Uncurried non-variadic functions with multiple return values
+      t@(TUncurriedFn _ as (r1:r2:rs)) -> do
+        tv <- fresh (getSourceInfo t)
+        tps <- mapM infer ps
+        uni (getSourceInfo tf) (TUncurriedFn (getSourceInfo tf) as [TTuple si r1 r2 rs])
+                               (TUncurriedFn (getSourceInfo tf) (map Core.typeOf tps) [tv])
+        return (Core.UncurriedFnApplication si tf tps tv)
+
+      -- Uncurried variadic functions (only single return value works for now)
       t@(TVariadicFn _ nonVariadicTypes variadicType _) -> do
         tv <- fresh (getSourceInfo t)
         nonVariadicParams <- mapM infer (take (length nonVariadicTypes) ps)
@@ -354,6 +341,14 @@ infer expr = case expr of
         let allParams = nonVariadicParams ++ [Core.Slice sliceSi variadicParams variadicType]
         uni (getSourceInfo tf) t (TVariadicFn (getSourceInfo tf) (map Core.typeOf nonVariadicParams) variadicType tv)
         return (Core.UncurriedFnApplication si tf allParams tv)
+
+      -- No-arg functions
+      t | ps == [] -> do
+        tv <- fresh (getSourceInfo t)
+        uni (getSourceInfo tf) t (TNoArgFn (getSourceInfo tf) tv)
+        return (Core.NoArgApplication si tf tv)
+
+      -- Everything else, i.e. functions with a single argument and one return value
       t ->
         foldM app tf ps
         where

--- a/src/Oden/Infer/Subsumption.hs
+++ b/src/Oden/Infer/Subsumption.hs
@@ -43,7 +43,7 @@ collectSubstitutions (TNoArgFn _ r1) (TNoArgFn _ r2) = collectSubstitutions r1 r
 collectSubstitutions (TUncurriedFn _ a1 r1) (TUncurriedFn _ a2 r2) =
   mapM_ (uncurry collectSubstitutions) ((zip r1 r2) ++ (zip a1 a2))
 collectSubstitutions (TVariadicFn _ a1 v1 r1) (TVariadicFn _ a2 v2 r2) =
-  mapM_ (uncurry collectSubstitutions) ((r1, r2) : (v1, v2) : zip a1 a2)
+  mapM_ (uncurry collectSubstitutions) ((v1, v2) : ((zip a1 a2) ++ (zip r1 r2)))
 collectSubstitutions (TSlice _ t1) (TSlice _ t2) = collectSubstitutions t1 t2
 collectSubstitutions (TTuple _ f1 s1 r1) (TTuple _ f2 s2 r2) = do
   collectSubstitutions f1 f2

--- a/src/Oden/Infer/Subsumption.hs
+++ b/src/Oden/Infer/Subsumption.hs
@@ -41,7 +41,7 @@ collectSubstitutions (TFn _ a1 r1) (TFn _ a2 r2) = do
   collectSubstitutions r1 r2
 collectSubstitutions (TNoArgFn _ r1) (TNoArgFn _ r2) = collectSubstitutions r1 r2
 collectSubstitutions (TUncurriedFn _ a1 r1) (TUncurriedFn _ a2 r2) =
-  mapM_ (uncurry collectSubstitutions) ((r1, r2) : zip a1 a2)
+  mapM_ (uncurry collectSubstitutions) ((zip r1 r2) ++ (zip a1 a2))
 collectSubstitutions (TVariadicFn _ a1 v1 r1) (TVariadicFn _ a2 v2 r2) =
   mapM_ (uncurry collectSubstitutions) ((r1, r2) : (v1, v2) : zip a1 a2)
 collectSubstitutions (TSlice _ t1) (TSlice _ t2) = collectSubstitutions t1 t2

--- a/src/Oden/Predefined.hs
+++ b/src/Oden/Predefined.hs
@@ -12,7 +12,7 @@ import qualified Data.Map as Map
 
 pairs :: [(Name, Scheme)]
 pairs = [
-  ("len", Forall Predefined [TVarBinding Predefined (TV "a")] (TUncurriedFn Predefined [TSlice Predefined (TVar Predefined (TV "a"))] (TBasic Predefined TInt)))
+  ("len", Forall Predefined [TVarBinding Predefined (TV "a")] (TUncurriedFn Predefined [TSlice Predefined (TVar Predefined (TV "a"))] [TBasic Predefined TInt]))
   ]
 
 predefined :: Map.Map Name Core.Definition

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -126,7 +126,7 @@ instance Pretty Mono.Type where
   pp (Mono.TNoArgFn _ t) = rArr <+> pp t
   pp (Mono.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
   pp (Mono.TUncurriedFn _ as [r]) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
-  pp (Mono.TUncurriedFn _ as rs) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> parens (hsep (punctuate (text ",") (map pp rs)))
+  pp (Mono.TUncurriedFn _ as rs) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> parens (hsep (punctuate (text ", ") (map pp rs)))
   pp (Mono.TVariadicFn _ as v r) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
   pp (Mono.TSlice _ t) =
     text "!" <> braces (pp t)

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -125,7 +125,7 @@ instance Pretty Mono.Type where
   pp (Mono.TCon _ d r) = pp d <> parens (pp r)
   pp (Mono.TNoArgFn _ t) = rArr <+> pp t
   pp (Mono.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
-  pp (Mono.TUncurriedFn _ as r) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
+  pp (Mono.TUncurriedFn _ as rs) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> hsep (punctuate (text "&") (map pp rs))
   pp (Mono.TVariadicFn _ as v r) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
   pp (Mono.TSlice _ t) =
     text "!" <> braces (pp t)

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -105,7 +105,8 @@ instance Pretty Poly.Type where
   pp (Poly.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
   pp (Poly.TUncurriedFn _ as [r]) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
   pp (Poly.TUncurriedFn _ as rs) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> braces (hsep (punctuate (text "&") (map pp rs)))
-  pp (Poly.TVariadicFn _ as v r) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
+  pp (Poly.TVariadicFn _ as v [r]) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
+  pp (Poly.TVariadicFn _ as v rs) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> braces (hsep (punctuate (text "&") (map pp rs)))
   pp (Poly.TSlice _ t) =
     text "[]" <> braces (pp t)
   pp (Poly.TStruct _ fs) = braces (hcat (punctuate (text "; ") (map pp fs)))
@@ -127,7 +128,8 @@ instance Pretty Mono.Type where
   pp (Mono.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
   pp (Mono.TUncurriedFn _ as [r]) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
   pp (Mono.TUncurriedFn _ as rs) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> parens (hsep (punctuate (text ", ") (map pp rs)))
-  pp (Mono.TVariadicFn _ as v r) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
+  pp (Mono.TVariadicFn _ as v [r]) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
+  pp (Mono.TVariadicFn _ as v rs) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> parens (hsep (punctuate (text ", ") (map pp rs)))
   pp (Mono.TSlice _ t) =
     text "!" <> braces (pp t)
   pp (Mono.TStruct _ fs) = braces (hcat (punctuate (text "; ") (map ppField fs)))

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -125,7 +125,8 @@ instance Pretty Mono.Type where
   pp (Mono.TCon _ d r) = pp d <> parens (pp r)
   pp (Mono.TNoArgFn _ t) = rArr <+> pp t
   pp (Mono.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
-  pp (Mono.TUncurriedFn _ as rs) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> hsep (punctuate (text "&") (map pp rs))
+  pp (Mono.TUncurriedFn _ as [r]) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
+  pp (Mono.TUncurriedFn _ as rs) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> parens (hsep (punctuate (text ",") (map pp rs)))
   pp (Mono.TVariadicFn _ as v r) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
   pp (Mono.TSlice _ t) =
     text "!" <> braces (pp t)

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -103,7 +103,8 @@ instance Pretty Poly.Type where
   pp (Poly.TCon _ d r) = pp d <> parens (pp r)
   pp (Poly.TNoArgFn _ t) = rArr <+> pp t
   pp (Poly.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
-  pp (Poly.TUncurriedFn _ as r) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
+  pp (Poly.TUncurriedFn _ as [r]) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
+  pp (Poly.TUncurriedFn _ as rs) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> braces (hsep (punctuate (text "&") (map pp rs)))
   pp (Poly.TVariadicFn _ as v r) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
   pp (Poly.TSlice _ t) =
     text "[]" <> braces (pp t)

--- a/src/Oden/Type/Monomorphic.hs
+++ b/src/Oden/Type/Monomorphic.hs
@@ -16,7 +16,7 @@ data Type
   | TCon SourceInfo Type Type
   | TNoArgFn SourceInfo Type
   | TFn SourceInfo Type Type
-  | TUncurriedFn SourceInfo [Type] Type
+  | TUncurriedFn SourceInfo [Type] [Type]
   | TVariadicFn SourceInfo [Type] Type Type
   | TSlice SourceInfo Type
   | TStruct SourceInfo [StructField]

--- a/src/Oden/Type/Monomorphic.hs
+++ b/src/Oden/Type/Monomorphic.hs
@@ -17,7 +17,7 @@ data Type
   | TNoArgFn SourceInfo Type
   | TFn SourceInfo Type Type
   | TUncurriedFn SourceInfo [Type] [Type]
-  | TVariadicFn SourceInfo [Type] Type Type
+  | TVariadicFn SourceInfo [Type] Type [Type]
   | TSlice SourceInfo Type
   | TStruct SourceInfo [StructField]
   | TNamed SourceInfo QualifiedName Type

--- a/src/Oden/Type/Polymorphic.hs
+++ b/src/Oden/Type/Polymorphic.hs
@@ -134,9 +134,9 @@ toMonomorphic (TCon si d r) = Mono.TCon si <$> toMonomorphic d <*> toMonomorphic
 toMonomorphic (TNoArgFn si t) = Mono.TNoArgFn si <$> toMonomorphic t
 toMonomorphic (TFn si tx ty) = Mono.TFn si <$> toMonomorphic tx
                                            <*> toMonomorphic ty
-toMonomorphic (TUncurriedFn si a (r:_)) =
+toMonomorphic (TUncurriedFn si a rs) =
   Mono.TUncurriedFn si <$> mapM toMonomorphic a
-                       <*> toMonomorphic r
+                       <*> mapM toMonomorphic rs
 toMonomorphic (TVariadicFn si a v r) =
   Mono.TVariadicFn si <$> mapM toMonomorphic a
                       <*> toMonomorphic v

--- a/src/Oden/Type/Polymorphic.hs
+++ b/src/Oden/Type/Polymorphic.hs
@@ -63,8 +63,7 @@ data Type
   -- For foreign definitions:
 
   -- | A function that can have multiple arguments (no currying).
-  | TUncurriedFn SourceInfo [Type] [Type] -- TODO: Support multiple return values somehow.
-  -- | A variadic function.
+  | TUncurriedFn SourceInfo [Type] [Type]
   | TVariadicFn SourceInfo [Type] Type Type -- TODO: Support multiple return values somehow.
   deriving (Show, Eq, Ord)
 

--- a/test/Oden/Compiler/InstantiateSpec.hs
+++ b/test/Oden/Compiler/InstantiateSpec.hs
@@ -44,7 +44,7 @@ identityInt =
   (Poly.TFn Missing typeInt typeInt)
 
 lenType :: Poly.Type
-lenType = Poly.TUncurriedFn Missing [Poly.TSlice Missing tvarA] typeInt
+lenType = Poly.TUncurriedFn Missing [Poly.TSlice Missing tvarA] [typeInt]
 
 lenPoly :: Core.Expr Poly.Type
 lenPoly = Core.Symbol Missing (Unqualified "len") lenType
@@ -57,7 +57,7 @@ lenInt =
   Core.Symbol
   Missing
   (Unqualified "len")
-  (Poly.TUncurriedFn Missing [Poly.TSlice Missing typeInt] typeInt)
+  (Poly.TUncurriedFn Missing [Poly.TSlice Missing typeInt] [typeInt])
 
 pairPoly :: Core.Expr Poly.Type
 pairPoly =

--- a/test/Oden/Compiler/InstantiateSpec.hs
+++ b/test/Oden/Compiler/InstantiateSpec.hs
@@ -50,7 +50,7 @@ lenPoly :: Core.Expr Poly.Type
 lenPoly = Core.Symbol Missing (Unqualified "len") lenType
 
 lenIntType :: Mono.Type
-lenIntType = Mono.TUncurriedFn Missing [Mono.TSlice Missing monoInt] monoInt
+lenIntType = Mono.TUncurriedFn Missing [Mono.TSlice Missing monoInt] [monoInt]
 
 lenInt :: Core.Expr Poly.Type
 lenInt =

--- a/test/Oden/Compiler/MonomorphizationSpec.hs
+++ b/test/Oden/Compiler/MonomorphizationSpec.hs
@@ -169,7 +169,7 @@ sliceLenMonomorphed =
     monoInt
     (Core.UncurriedFnApplication
      Missing
-     (Core.Symbol Missing (Unqualified "len") (Mono.TUncurriedFn Missing [Mono.TSlice Missing monoBool] monoInt))
+     (Core.Symbol Missing (Unqualified "len") (Mono.TUncurriedFn Missing [Mono.TSlice Missing monoBool] [monoInt]))
      [Core.Slice Missing [Core.Literal Missing (Core.Bool True) monoBool] (Mono.TSlice Missing (Mono.TBasic Missing TBool))]
      monoInt)
 

--- a/test/Oden/Compiler/MonomorphizationSpec.hs
+++ b/test/Oden/Compiler/MonomorphizationSpec.hs
@@ -157,7 +157,7 @@ sliceLenDef =
     (Poly.Forall Missing [] typeInt,
      Core.UncurriedFnApplication
       Missing
-      (Core.Symbol Missing (Unqualified "len") (Poly.TUncurriedFn Missing [Poly.TSlice Missing typeBool] typeInt))
+      (Core.Symbol Missing (Unqualified "len") (Poly.TUncurriedFn Missing [Poly.TSlice Missing typeBool] [typeInt]))
       [Core.Slice Missing [Core.Literal Missing (Core.Bool True) typeBool] (Poly.TSlice Missing typeBool)]
       typeInt)
 

--- a/test/Oden/Compiler/TypeEncoderSpec.hs
+++ b/test/Oden/Compiler/TypeEncoderSpec.hs
@@ -21,9 +21,11 @@ spec =
       encodeTypeInstance (Unqualified "foo") (TNoArgFn Missing (TNoArgFn Missing (TBasic Missing TInt))) `shouldBe` "foo_inst_to_to__int"
     it "encodes uncurried func" $
       encodeTypeInstance (Unqualified "foo") (TUncurriedFn Missing [TBasic Missing TBool, TBasic Missing TInt] [TBasic Missing TString]) `shouldBe` "foo_inst_bool_to_int_to_string"
-    it "encodes uncurried funcs with multipe return values" $
+    it "encodes uncurried funcs with multiple return values" $
       encodeTypeInstance (Unqualified "foo") (TUncurriedFn Missing [TBasic Missing TBool, TBasic Missing TInt] [TBasic Missing TString, TBasic Missing TInt]) `shouldBe` "foo_inst_bool_to_int_to_tupleof__string__int__"
     it "encodes variadic func" $
-      encodeTypeInstance (Unqualified "foo") (TVariadicFn Missing [TBasic Missing TBool] (TBasic Missing TInt) (TBasic Missing TString)) `shouldBe` "foo_inst_bool_to_variadic_int_to_string"
+      encodeTypeInstance (Unqualified "foo") (TVariadicFn Missing [TBasic Missing TBool] (TBasic Missing TInt) [TBasic Missing TString]) `shouldBe` "foo_inst_bool_to_variadic_int_to_string"
+    it "encodes variadic func with multiple return values" $
+      encodeTypeInstance (Unqualified "foo") (TVariadicFn Missing [TBasic Missing TBool] (TBasic Missing TInt) [TBasic Missing TString, TBasic Missing TInt]) `shouldBe` "foo_inst_bool_to_variadic_int_to_tupleof__string__int__"
     it "encodes slice" $
       encodeTypeInstance (Unqualified "foo") (TFn Missing (TSlice Missing (TBasic Missing TBool)) (TSlice Missing (TBasic Missing TInt))) `shouldBe` "foo_inst_sliceof__bool_to_sliceof__int"

--- a/test/Oden/Compiler/TypeEncoderSpec.hs
+++ b/test/Oden/Compiler/TypeEncoderSpec.hs
@@ -20,7 +20,9 @@ spec =
     it "encodes nested single arrows" $
       encodeTypeInstance (Unqualified "foo") (TNoArgFn Missing (TNoArgFn Missing (TBasic Missing TInt))) `shouldBe` "foo_inst_to_to__int"
     it "encodes uncurried func" $
-      encodeTypeInstance (Unqualified "foo") (TUncurriedFn Missing [TBasic Missing TBool, TBasic Missing TInt] (TBasic Missing TString)) `shouldBe` "foo_inst_bool_to_int_to_string"
+      encodeTypeInstance (Unqualified "foo") (TUncurriedFn Missing [TBasic Missing TBool, TBasic Missing TInt] [TBasic Missing TString]) `shouldBe` "foo_inst_bool_to_int_to_string"
+    it "encodes uncurried funcs with multipe return values" $
+      encodeTypeInstance (Unqualified "foo") (TUncurriedFn Missing [TBasic Missing TBool, TBasic Missing TInt] [TBasic Missing TString, TBasic Missing TInt]) `shouldBe` "foo_inst_bool_to_int_to_tupleof__string__int__"
     it "encodes variadic func" $
       encodeTypeInstance (Unqualified "foo") (TVariadicFn Missing [TBasic Missing TBool] (TBasic Missing TInt) (TBasic Missing TString)) `shouldBe` "foo_inst_bool_to_variadic_int_to_string"
     it "encodes slice" $

--- a/test/Oden/InferSpec.hs
+++ b/test/Oden/InferSpec.hs
@@ -116,7 +116,11 @@ predefAndSwap = predef `extend` ("swap",
 
 predefAndMaxVariadic :: TypingEnvironment
 predefAndMaxVariadic = predef `extend` ("max",
-                                        Local Predefined "max" $ forall [] (typeVariadic [] typeInt typeInt))
+                                        Local Predefined "max" $ forall [] (typeVariadic [] typeInt [typeInt]))
+
+predefAndMaxMinVariadic :: TypingEnvironment
+predefAndMaxMinVariadic = predef `extend` ("maxmin",
+                                        Local Predefined "maxmin" $ forall [] (typeVariadic [] typeInt [typeInt, typeInt]))
 
 predefAndIdentityAny :: TypingEnvironment
 predefAndIdentityAny = predef `extend` ("identity",
@@ -423,7 +427,7 @@ spec = do
                                                           ,uLiteral (uInt 1)])
       `shouldSucceedWith`
       (forall [] typeInt,
-       tUncurriedFnApplication (tSymbol (Unqualified "max") (typeVariadic [] typeInt typeInt))
+       tUncurriedFnApplication (tSymbol (Unqualified "max") (typeVariadic [] typeInt [typeInt]))
                               [tSlice [tLiteral (tInt 0) typeInt
                                           ,tLiteral (tInt 1) typeInt] typeInt]
        typeInt)
@@ -432,9 +436,27 @@ spec = do
       inferExpr predefAndMaxVariadic (uApplication (uSymbol (Unqualified "max")) [])
       `shouldSucceedWith`
       (forall [] typeInt,
-       tUncurriedFnApplication (tSymbol (Unqualified "max") (typeVariadic [] typeInt typeInt))
+       tUncurriedFnApplication (tSymbol (Unqualified "max") (typeVariadic [] typeInt [typeInt]))
                               [tSlice [] typeInt]
        typeInt)
+
+    it "infers variadic func application with multipe return values" $
+      inferExpr predefAndMaxMinVariadic (uApplication (uSymbol (Unqualified "maxmin"))
+                                                      [uLiteral (uInt 0), uLiteral (uInt 1)])
+      `shouldSucceedWith`
+      (forall [] (TTuple Missing typeInt typeInt []),
+       tUncurriedFnApplication (tSymbol (Unqualified "maxmin") (typeVariadic [] typeInt [typeInt, typeInt]))
+                              [tSlice [tLiteral (tInt 0) typeInt, tLiteral (tInt 1) typeInt ] typeInt]
+       (TTuple Missing typeInt typeInt []))
+
+
+    it "infers variadic no-arg func application with multipe return values" $
+      inferExpr predefAndMaxMinVariadic (uApplication (uSymbol (Unqualified "maxmin")) [])
+      `shouldSucceedWith`
+      (forall [] (TTuple Missing typeInt typeInt []),
+       tUncurriedFnApplication (tSymbol (Unqualified "maxmin") (typeVariadic [] typeInt [typeInt, typeInt]))
+                              [tSlice [] typeInt]
+       (TTuple Missing typeInt typeInt []))
 
     it "infers struct initializer" $
       let structType = (TStruct Missing [TStructField Missing "msg" (TBasic Missing TString)]) in

--- a/test/Oden/InferSpec.hs
+++ b/test/Oden/InferSpec.hs
@@ -110,6 +110,10 @@ predefAndPair :: TypingEnvironment
 predefAndPair = predef `extend` ("pair",
                                  Local Predefined "pair" $ forall [] (typeUncurried [] [typeInt, typeString]))
 
+predefAndSwap :: TypingEnvironment
+predefAndSwap = predef `extend` ("swap",
+                                 Local Predefined "swap" $ forall [] (typeUncurried [typeString, typeInt] [typeInt, typeString]))
+
 predefAndMaxVariadic :: TypingEnvironment
 predefAndMaxVariadic = predef `extend` ("max",
                                         Local Predefined "max" $ forall [] (typeVariadic [] typeInt typeInt))
@@ -399,6 +403,18 @@ spec = do
       `shouldSucceedWith`
       (forall [] (TTuple Missing typeInt typeString []),
        tUncurriedFnApplication (tSymbol (Unqualified "pair") (typeUncurried [] [typeInt, typeString])) []
+       (TTuple Missing typeInt typeString []))
+
+    it "infers two arg uncurried multi-value func application" $
+      inferExpr predefAndSwap (uApplication (uSymbol (Unqualified "swap"))
+                                                     [uLiteral (uString "hey")
+                                                     ,uLiteral (uInt 1)])
+      `shouldSucceedWith`
+      (forall [] (TTuple Missing typeInt typeString []),
+       tUncurriedFnApplication (tSymbol (Unqualified "swap")
+                                        (typeUncurried [typeString, typeInt] [typeInt, typeString]))
+                               [tLiteral (tString "hey") typeString
+                               ,tLiteral (tInt 1) typeInt]
        (TTuple Missing typeInt typeString []))
 
     it "infers variadic func application" $

--- a/test/Oden/InferSpec.hs
+++ b/test/Oden/InferSpec.hs
@@ -106,6 +106,10 @@ predefAndMax :: TypingEnvironment
 predefAndMax =  predef `extend` ("max",
                                  Local Predefined "max" $ forall [] (typeUncurried [typeInt, typeInt] [typeInt]))
 
+predefAndPair :: TypingEnvironment
+predefAndPair = predef `extend` ("pair",
+                                 Local Predefined "pair" $ forall [] (typeUncurried [] [typeInt, typeString]))
+
 predefAndMaxVariadic :: TypingEnvironment
 predefAndMaxVariadic = predef `extend` ("max",
                                         Local Predefined "max" $ forall [] (typeVariadic [] typeInt typeInt))
@@ -379,7 +383,7 @@ spec = do
                               [Core.Slice Missing [Core.Literal Missing (tBool True) typeBool] (typeSlice typeBool)]
        (TBasic Predefined TInt))
 
-    it "infers single-arg uncurried func application" $
+    it "infers two arg uncurried func application" $
       inferExpr predefAndMax (uApplication (uSymbol (Unqualified "max"))
                                                   [uLiteral (uInt 0)
                                                   ,uLiteral (uInt 1)])
@@ -389,6 +393,13 @@ spec = do
                               [tLiteral (tInt 0) typeInt
                               ,tLiteral (tInt 1) typeInt]
        typeInt)
+
+    it "infers no-arg uncurried multi-value func application" $
+      inferExpr predefAndPair (uApplication (uSymbol (Unqualified "pair")) [])
+      `shouldSucceedWith`
+      (forall [] (TTuple Missing typeInt typeString []),
+       tUncurriedFnApplication (tSymbol (Unqualified "pair") (typeUncurried [] [typeInt, typeString])) []
+       (TTuple Missing typeInt typeString []))
 
     it "infers variadic func application" $
       inferExpr predefAndMaxVariadic (uApplication (uSymbol (Unqualified "max"))

--- a/test/Oden/InferSpec.hs
+++ b/test/Oden/InferSpec.hs
@@ -104,7 +104,7 @@ predefAndStringLength =  predef `extend` ("stringLength",
 
 predefAndMax :: TypingEnvironment
 predefAndMax =  predef `extend` ("max",
-                                 Local Predefined "max" $ forall [] (typeUncurried [typeInt, typeInt] typeInt))
+                                 Local Predefined "max" $ forall [] (typeUncurried [typeInt, typeInt] [typeInt]))
 
 predefAndMaxVariadic :: TypingEnvironment
 predefAndMaxVariadic = predef `extend` ("max",
@@ -112,7 +112,7 @@ predefAndMaxVariadic = predef `extend` ("max",
 
 predefAndIdentityAny :: TypingEnvironment
 predefAndIdentityAny = predef `extend` ("identity",
-                                        Local Predefined "identity" $ forall [] (typeUncurried [typeAny] (typeAny)))
+                                        Local Predefined "identity" $ forall [] (typeUncurried [typeAny] ([typeAny])))
 
 booleanOp :: Type
 booleanOp = typeFn typeBool (typeFn typeBool typeBool)
@@ -299,7 +299,7 @@ spec = do
       `shouldSucceedWith`
       (forall [] typeAny,
        tUncurriedFnApplication
-        (tSymbol (Unqualified "identity") (typeUncurried [typeAny] typeAny))
+        (tSymbol (Unqualified "identity") (typeUncurried [typeAny] [typeAny]))
         [tLiteral (tBool False) typeBool]
         typeAny)
 
@@ -329,9 +329,9 @@ spec = do
       `shouldSucceedWith`
       (forall [] typeAny,
        tUncurriedFnApplication
-        (tSymbol (Unqualified "identity") (typeUncurried [typeAny] typeAny))
+        (tSymbol (Unqualified "identity") (typeUncurried [typeAny] [typeAny]))
         [tUncurriedFnApplication
-         (tSymbol (Unqualified "identity") (typeUncurried [typeAny] typeAny))
+         (tSymbol (Unqualified "identity") (typeUncurried [typeAny] [typeAny]))
          [tLiteral (tBool False) typeBool]
          typeAny]
         typeAny)
@@ -375,7 +375,7 @@ spec = do
       inferExpr predef (uApplication (uSymbol (Unqualified "len")) [uSlice [uLiteral (uBool True)]])
       `shouldSucceedWith`
       (forall [] (TBasic Predefined TInt),
-       tUncurriedFnApplication (Core.Symbol Missing (Unqualified "len") (TUncurriedFn Missing [TSlice Predefined (TBasic Missing TBool)] (TBasic Predefined TInt)))
+       tUncurriedFnApplication (Core.Symbol Missing (Unqualified "len") (TUncurriedFn Missing [TSlice Predefined (TBasic Missing TBool)] [TBasic Predefined TInt]))
                               [Core.Slice Missing [Core.Literal Missing (tBool True) typeBool] (typeSlice typeBool)]
        (TBasic Predefined TInt))
 
@@ -385,7 +385,7 @@ spec = do
                                                   ,uLiteral (uInt 1)])
       `shouldSucceedWith`
       (forall [] typeInt,
-       tUncurriedFnApplication (tSymbol (Unqualified "max") (typeUncurried [typeInt, typeInt] typeInt))
+       tUncurriedFnApplication (tSymbol (Unqualified "max") (typeUncurried [typeInt, typeInt] [typeInt]))
                               [tLiteral (tInt 0) typeInt
                               ,tLiteral (tInt 1) typeInt]
        typeInt)


### PR DESCRIPTION
Here is support for multiple return values, which is mentioned in issue #56.

So far, only non-variadic functions are supported. I will add it to variadic functions as well, either in this pull-request or a new one.

There are a bunch of code changes in this pull request, but it basically boils down to:

* All types regarding uncurried functions now contain an array of return types, instead of a single return type. E.g. in Polymorphic.hs: `TUncurriedFn SourceInfo [Type] Type` is changed to `TUncurriedFn SourceInfo [Type] [Type]`. This accounts for a lot of minor code changes all over the place.

* In Infer.hs, the unification of the return type of a multi-value function will unify against a Tuple type containing the return types. For single valued functions,  the single return value is still used as before.

* When generating the resulting go, code. A call to a multi-valued function is wrapped in an anonymous function, "packing" the return values into a struct, representing the tuple:
```Go
// multi.go:
package multi
func mul() (int, string) { return 3, "foo"}

// Oden code:
// import "multi"
// let x = multi.mul()

// Resulting Go code:
var x struct{_0 int; _1 string} = func (_0 int, _1 string) struct{_0 int; _1 string} {
   return struct{_0 int; _1 string}{_0, _1}
}(multi.mul())
```