### PR TITLE
Don't create tarbomb releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ dist/oden: dist/build-oden-cli/bin/oden
 	cp dist/build-oden-cli/bin/oden dist/oden/bin/oden
 
 $(DIST_ARCHIVE): dist/oden
-	(cd dist/oden && tar -czf ../$(DIST_NAME).tar.gz .)
+	(cd dist && tar -czf $(DIST_NAME).tar.gz oden)
 
 dist: $(DIST_ARCHIVE)
 


### PR DESCRIPTION
Currently, `tar xf $DIST_ARCHIVE` creates all the files in the current directory, which is annoying if the user is at $HOME. It should instead create a new directory 'oden' with all the files inside.