### PR TITLE
TForeignFn and wrapped foreign applications

### DIFF
--- a/regression-test/src/blocks/main.oden
+++ b/regression-test/src/blocks/main.oden
@@ -3,9 +3,9 @@ package blocks/main
 import fmt
 
 result = {
-  fmt.Println("Calculating...")
+  println("Calculating...")
   42
 }
 
 main : -> ()
-main() = fmt.Println(result)
+main() = println(result)

--- a/regression-test/src/comments/main.oden
+++ b/regression-test/src/comments/main.oden
@@ -5,4 +5,4 @@ import fmt
 /* this is a multiline comment */
 // this is a single line comment
 
-main() = /* they can be added here and there... */ fmt.Println("I've got nothing to say.") // it works here as well
+main() = /* they can be added here and there... */ println("I've got nothing to say.") // it works here as well

--- a/regression-test/src/definitions/main.oden
+++ b/regression-test/src/definitions/main.oden
@@ -6,4 +6,4 @@ hello = "Hello"
 
 helloWorld = hello ++ ", world!"
 
-main() = fmt.Println(helloWorld)
+main() = println(helloWorld)

--- a/regression-test/src/factorial/main.oden
+++ b/regression-test/src/factorial/main.oden
@@ -4,4 +4,4 @@ import fmt
 
 factorial(n) = if n < 2 then 1 else n * factorial(n - 1)
 
-main() = fmt.Println(factorial(5))
+main() = println(factorial(5))

--- a/regression-test/src/fibonacci/main.oden
+++ b/regression-test/src/fibonacci/main.oden
@@ -8,4 +8,4 @@ fib(n) = if n == 1 then 0 else {
   }
 }
 
-main() = fmt.Println(fib(10))
+main() = println(fib(10))

--- a/regression-test/src/higherorder/main.oden
+++ b/regression-test/src/higherorder/main.oden
@@ -6,4 +6,4 @@ identity(x) = x
 
 applyTo1(x) = x(1)
 
-main() = fmt.Println((identity(applyTo1))((x) -> x * 2))
+main() = println((identity(applyTo1))((x) -> x * 2))

--- a/regression-test/src/let/main.oden
+++ b/regression-test/src/let/main.oden
@@ -2,4 +2,4 @@ package let/main
 
 import fmt
 
-main() = fmt.Println(let name = "Foo" in name ++ "!")
+main() = println(let name = "Foo" in name ++ "!")

--- a/regression-test/src/letpoly/main.oden
+++ b/regression-test/src/letpoly/main.oden
@@ -4,4 +4,4 @@ import fmt
 
 identity(x) = x
 
-main() = fmt.Println(let id = identity(identity) in id("a"))
+main() = println(let id = identity(identity) in id("a"))

--- a/regression-test/src/letreuse.oden
+++ b/regression-test/src/letreuse.oden
@@ -9,4 +9,4 @@ id2 : forall a. a -> a
 id2(x) = let t = (v) -> id(v) in t(id(x))
 
 main : -> ()
-main() = fmt.Println(id2(1))
+main() = println(id2(1))

--- a/regression-test/src/logic/main.oden
+++ b/regression-test/src/logic/main.oden
@@ -2,4 +2,4 @@ package logic/main
 
 import fmt
 
-main() = fmt.Println(if !(true && false) || false then "yey" else "ney")
+main() = println(if !(true && false) || false then "yey" else "ney")

--- a/regression-test/src/main.oden
+++ b/regression-test/src/main.oden
@@ -1,12 +1,9 @@
 // package declaration
 package main
 
-// import declaration
-import fmt
-
 identityString(x) = "" ++ x
 
 result = identityString("Hello") ++ ", world!"
 
 // main function definition, must have type (-> unit)
-main() = fmt.Println(result)
+main() = println(result)

--- a/regression-test/src/numbers/main.oden
+++ b/regression-test/src/numbers/main.oden
@@ -6,4 +6,4 @@ plus(x, y) = x + y
 
 plus1 = plus(1)
 
-main() = fmt.Println(plus1(plus1(-10)))
+main() = println(plus1(plus1(-10)))

--- a/regression-test/src/pair/main.oden
+++ b/regression-test/src/pair/main.oden
@@ -8,4 +8,4 @@ first(p) = p((x, y) -> x)
 
 p = pair("a", "b")
 
-main() = fmt.Println(first(p))
+main() = println(first(p))

--- a/regression-test/src/pairlet/main.oden
+++ b/regression-test/src/pairlet/main.oden
@@ -7,5 +7,5 @@ pair(x, y, f) = f(x, y)
 first(p) = p((x, y) -> x)
 
 main() = {
-  fmt.Println(let p = pair("a", 1) in first(p))
+  println(let p = pair("a", 1) in first(p))
 }

--- a/regression-test/src/records.oden
+++ b/regression-test/src/records.oden
@@ -14,7 +14,7 @@ bar = {
 
 // Accepts nested record, as defined by 'Bar' and 'Foo' above.
 printFooName : Bar -> ()
-printFooName(x) = fmt.Println(x.foo.name)
+printFooName(x) = println(x.foo.name)
 
 // Accept any record with a name field.
 anyTypeOfName : forall a. a -> { name: a }
@@ -29,8 +29,8 @@ getName(x) = x.name
 
 main() = {
   printFooName(bar)
-  fmt.Println(poly.name)
-  fmt.Println(getName({
+  println(poly.name)
+  println(getName({
     name = "passing a record like this",
     age = 42
   }))

--- a/regression-test/src/rowvar.oden
+++ b/regression-test/src/rowvar.oden
@@ -6,6 +6,6 @@ getBar : forall a r. { bar: a | r } -> a
 getBar(r) = r.bar
 
 main() = {
-  fmt.Println(getBar({ bar = 123 }))
-  fmt.Println(getBar({ bar = 123, baz = "not ok" }))
+  println(getBar({ bar = 123 }))
+  println(getBar({ bar = 123, baz = "not ok" }))
 }

--- a/regression-test/src/slices/main.oden
+++ b/regression-test/src/slices/main.oden
@@ -4,5 +4,7 @@ import fmt
 
 main : -> ()
 main() = let x = -200 in {
-  fmt.Println(-x, []{"OK"})
+  print(-x)
+  print(" ")
+  println([]{"OK"})
 }

--- a/regression-test/src/tuples/main.oden
+++ b/regression-test/src/tuples/main.oden
@@ -12,15 +12,15 @@ pair(x, y) = (x, y)
 
 main : -> ()
 main() = {
-  fmt.Println(stuff)
+  println(stuff)
 
   if (1, 2, 3) == (1, 2, 3) then {
-    fmt.Println("Equality works.")
+    println("Equality works.")
   } else {
-    fmt.Println("OMG no!")
+    println("OMG no!")
   }
 
-  fmt.Println(pair(2, "hello") == (2, "hello"))
+  println(pair(2, "hello") == (2, "hello"))
 
   nothing
 }

--- a/regression-test/src/typealias.oden
+++ b/regression-test/src/typealias.oden
@@ -14,6 +14,6 @@ first(p) = p((x, y) -> x)
 p : IntPair
 p = pair(1, 2)
 
-main() = fmt.Println(first(p))
+main() = println(first(p))
 
 

--- a/regression-test/src/typesig/main.oden
+++ b/regression-test/src/typesig/main.oden
@@ -10,6 +10,6 @@ identityExplicit(x) = x
 theMessage : string
 theMessage = "Type signatures work!"
 
-main() = fmt.Println(
+main() = println(
   identityExplicit(
       identityNoTypeSig(theMessage)))

--- a/regression-test/src/unicode/main.oden
+++ b/regression-test/src/unicode/main.oden
@@ -3,5 +3,5 @@ package unicode/main
 import fmt
 
 main() = {
-  fmt.Println("As a [Swede], \229äö is what I want to write. \\\\ \"oh yeah\"")
+  println("As a [Swede], \229äö is what I want to write. \\\\ \"oh yeah\"")
 }

--- a/regression-test/src/unit/main.oden
+++ b/regression-test/src/unit/main.oden
@@ -4,4 +4,4 @@ import fmt
 
 testing = ()
 
-main() = fmt.Println("wtf...")
+main() = println("wtf...")

--- a/regression-test/src/void/main.oden
+++ b/regression-test/src/void/main.oden
@@ -4,6 +4,6 @@ import fmt
 
 main() =
   let
-    x = fmt.Print("unit: ")
+    x = print("unit: ")
   in
-    fmt.Println(x)
+    println(x)

--- a/src/Oden/Backend/Go.hs
+++ b/src/Oden/Backend/Go.hs
@@ -259,7 +259,7 @@ codegenExpr (BinaryOp _ o e1 e2 _) = do
 codegenExpr (Application _ f p _) =
   (<>) <$> codegenExpr f <*> (parens <$> codegenExpr p)
 
-codegenExpr (UncurriedFnApplication _ f args _) =
+codegenExpr (ForeignFnApplication _ f args _) =
   case typeOf f of
 
     -- Go functions that return unit are (almost always) void functions

--- a/src/Oden/Backend/Go.hs
+++ b/src/Oden/Backend/Go.hs
@@ -112,7 +112,6 @@ codegenType (Mono.TTuple _ f s r) = do
   codegenTupleField n t = do
     tc <- codegenType t
     return $ text ("_" ++ show n) <+> tc
-codegenType Mono.TAny{} = return $ text "interface{}"
 codegenType (Mono.TNoArgFn _ f) = do
   fc <- codegenType f
   return $func empty empty fc empty

--- a/src/Oden/Compiler/Instantiate.hs
+++ b/src/Oden/Compiler/Instantiate.hs
@@ -157,10 +157,10 @@ instantiateExpr (Core.Application si f p t) =
 instantiateExpr (Core.NoArgApplication si f t) =
   Core.NoArgApplication si <$> instantiateExpr f
                            <*> replace t
-instantiateExpr (Core.UncurriedFnApplication si f ps t) =
-  Core.UncurriedFnApplication si <$> instantiateExpr f
-                                 <*> mapM instantiateExpr ps
-                                 <*> replace t
+instantiateExpr (Core.ForeignFnApplication si f ps t) =
+  Core.ForeignFnApplication si <$> instantiateExpr f
+                               <*> mapM instantiateExpr ps
+                               <*> replace t
 instantiateExpr (Core.Fn si a b t) =
   Core.Fn si a <$> instantiateExpr b
                <*> replace t

--- a/src/Oden/Compiler/Instantiate.hs
+++ b/src/Oden/Compiler/Instantiate.hs
@@ -24,12 +24,13 @@ type Instantiate a = StateT Substitutions (Except InstantiateError) a
 
 monoToPoly :: Mono.Type -> Poly.Type
 monoToPoly (Mono.TAny si) = Poly.TAny si
-monoToPoly (Mono.TTuple si f s r) = Poly.TTuple si (monoToPoly f) (monoToPoly s) (map monoToPoly r)
+monoToPoly (Mono.TTuple si f s r) =
+  Poly.TTuple si (monoToPoly f) (monoToPoly s) (map monoToPoly r)
 monoToPoly (Mono.TCon si n) = Poly.TCon si n
 monoToPoly (Mono.TNoArgFn si f) = Poly.TNoArgFn si (monoToPoly f)
 monoToPoly (Mono.TFn si f p) = Poly.TFn si (monoToPoly f) (monoToPoly p)
-monoToPoly (Mono.TUncurriedFn si as r) = Poly.TUncurriedFn si (map monoToPoly as) (map monoToPoly r)
-monoToPoly (Mono.TVariadicFn si as v r) = Poly.TVariadicFn si (map monoToPoly as) (monoToPoly v) (map monoToPoly r)
+monoToPoly (Mono.TForeignFn si variadic as r) =
+  Poly.TForeignFn si variadic (map monoToPoly as) (map monoToPoly r)
 monoToPoly (Mono.TSlice si t) = Poly.TSlice si (monoToPoly t)
 monoToPoly (Mono.TRecord si row) = Poly.TRecord si (monoToPoly row)
 monoToPoly (Mono.TNamed si n t) = Poly.TNamed si n (monoToPoly t)
@@ -47,15 +48,10 @@ getSubstitutions (Poly.TFn _ pf pp) (Mono.TFn _ mf mp) = do
   ps <- getSubstitutions pp mp
   return (fs `mappend` ps)
 getSubstitutions (Poly.TVar _ v) mono = Right (Map.singleton v (monoToPoly mono))
-getSubstitutions (Poly.TUncurriedFn _ pas prs) (Mono.TUncurriedFn _ mas mrs) = do
+getSubstitutions (Poly.TForeignFn _ _ pas prs) (Mono.TForeignFn _ _ mas mrs) = do
   as <- zipWithM getSubstitutions pas mas
   rs <- zipWithM getSubstitutions prs mrs
-  return (mconcat (rs ++ as))
-getSubstitutions (Poly.TVariadicFn _ pas pv prs) (Mono.TVariadicFn _ mas mv mrs) = do
-  as <- zipWithM getSubstitutions pas mas
-  rs <- zipWithM getSubstitutions prs mrs
-  v <- getSubstitutions pv mv
-  return (mconcat (v:(as ++ rs)))
+  return (mconcat (as ++ rs))
 getSubstitutions (Poly.TTuple _ pf ps pr) (Mono.TTuple _ mf ms mr) = do
   f <- getSubstitutions pf mf
   s <- getSubstitutions ps ms
@@ -105,10 +101,8 @@ replace (Poly.TVar (Metadata si) v) = do
 replace (Poly.TCon si n) = return (Poly.TCon si n)
 replace (Poly.TNoArgFn si t) = Poly.TNoArgFn si <$> replace t
 replace (Poly.TFn si ft pt) = Poly.TFn si <$> replace ft <*> replace pt
-replace (Poly.TUncurriedFn si ft pt) =
-  Poly.TUncurriedFn si <$> mapM replace ft <*> mapM replace pt
-replace (Poly.TVariadicFn si ft vt pt) =
-  Poly.TVariadicFn si <$> mapM replace ft <*> replace vt <*> mapM replace pt
+replace (Poly.TForeignFn si variadic ft pt) =
+  Poly.TForeignFn si variadic <$> mapM replace ft <*> mapM replace pt
 replace (Poly.TSlice si t) = Poly.TSlice si <$> replace t
 replace (Poly.TRecord si r) = Poly.TRecord si <$> replace r
 replace (Poly.TNamed si n t) = Poly.TNamed si n <$> replace t

--- a/src/Oden/Compiler/Instantiate.hs
+++ b/src/Oden/Compiler/Instantiate.hs
@@ -23,7 +23,6 @@ type Substitutions = Map.Map Poly.TVar Poly.Type
 type Instantiate a = StateT Substitutions (Except InstantiateError) a
 
 monoToPoly :: Mono.Type -> Poly.Type
-monoToPoly (Mono.TAny si) = Poly.TAny si
 monoToPoly (Mono.TTuple si f s r) =
   Poly.TTuple si (monoToPoly f) (monoToPoly s) (map monoToPoly r)
 monoToPoly (Mono.TCon si n) = Poly.TCon si n
@@ -90,7 +89,6 @@ getSubstitutions Poly.REmpty{} Mono.REmpty{} = return Map.empty
 getSubstitutions poly mono = throwError (TypeMismatch (getSourceInfo mono) poly mono)
 
 replace :: Poly.Type -> Instantiate Poly.Type
-replace (Poly.TAny si) = return (Poly.TAny si)
 replace (Poly.TTuple si f s r) =
   Poly.TTuple si <$> replace f <*> replace s <*> mapM replace r
 replace (Poly.TVar (Metadata si) v) = do

--- a/src/Oden/Compiler/Monomorphization.hs
+++ b/src/Oden/Compiler/Monomorphization.hs
@@ -185,11 +185,11 @@ monomorph e = case e of
     mf <- monomorph f
     return (Core.NoArgApplication si mf mt)
 
-  Core.UncurriedFnApplication si f ps _ -> do
+  Core.ForeignFnApplication si f ps _ -> do
     mt <- getMonoType e
     mf <- monomorph f
     mps <- mapM monomorph ps
-    return (Core.UncurriedFnApplication si mf mps mt)
+    return (Core.ForeignFnApplication si mf mps mt)
 
   Core.Fn si param@(Core.NameBinding _ identifier) b _ -> do
     mt <- getMonoType e

--- a/src/Oden/Compiler/TypeEncoder.hs
+++ b/src/Oden/Compiler/TypeEncoder.hs
@@ -36,7 +36,6 @@ writeQualified (FQN pkgs name) = do
   tell (intercalate "_" parts)
 
 writeType :: Mono.Type -> TypeEncoder ()
-writeType (Mono.TAny _) = tell "any"
 writeType (Mono.TCon _ n) = writeQualified n
 writeType (Mono.TTuple _ f s r) = do
   tell "tupleof"

--- a/src/Oden/Compiler/TypeEncoder.hs
+++ b/src/Oden/Compiler/TypeEncoder.hs
@@ -4,7 +4,7 @@ module Oden.Compiler.TypeEncoder (
 
 import           Control.Monad.State
 import           Control.Monad.Writer
-import           Data.List             (intercalate, sortOn)
+import           Data.List             (intercalate, intersperse, sortOn)
 
 import           Oden.Identifier
 import           Oden.QualifiedName    (QualifiedName(..))
@@ -52,26 +52,16 @@ writeType (Mono.TFn _ tl tr) = do
   withIncreasedLevel (writeType tl)
   paddedTo
   withIncreasedLevel (writeType tr)
-writeType (Mono.TUncurriedFn si as rs) = do
-  foldl writeArg (return ()) as
-  case rs of
-    [] -> undefined
-    [r] -> withIncreasedLevel (writeType r)
-    (r1:r2:rt) -> withIncreasedLevel $ writeType (Mono.TTuple si r1 r2 rt)
-  where
-  writeArg a t = a >> withIncreasedLevel (writeType t) >> paddedTo
-writeType (Mono.TVariadicFn si as v rs) = do
-  foldl writeArg (return ()) as
-  tell "variadic"
-  pad
-  withIncreasedLevel (writeType v)
+writeType (Mono.TForeignFn si variadic ps rs) = do
+  sequence_ (intersperse paddedTo (map (withIncreasedLevel . writeType) ps))
+  when variadic $ do
+    pad
+    tell "variadic"
   paddedTo
   case rs of
     [] -> undefined
     [r] -> withIncreasedLevel (writeType r)
     (r1:r2:rt) -> withIncreasedLevel $ writeType (Mono.TTuple si r1 r2 rt)
-  where
-  writeArg a t = a >> withIncreasedLevel (writeType t) >> paddedTo
 writeType (Mono.TSlice _ t) = do
   tell "sliceof"
   pad

--- a/src/Oden/Compiler/Validation.hs
+++ b/src/Oden/Compiler/Validation.hs
@@ -54,7 +54,7 @@ validateExpr (Application _ f arg _) = do
   validateExpr arg
 validateExpr (NoArgApplication _ f _) =
   validateExpr f
-validateExpr (UncurriedFnApplication _ f args _) = do
+validateExpr (ForeignFnApplication _ f args _) = do
   validateExpr f
   mapM_ validateExpr args
 validateExpr (Fn _ (NameBinding si name) body _) =  do

--- a/src/Oden/Core.hs
+++ b/src/Oden/Core.hs
@@ -21,7 +21,7 @@ data Expr t = Symbol (Metadata SourceInfo) Identifier t
             | BinaryOp (Metadata SourceInfo) BinaryOperator (Expr t) (Expr t) t
             | Application (Metadata SourceInfo) (Expr t) (Expr t) t
             | NoArgApplication (Metadata SourceInfo) (Expr t) t
-            | UncurriedFnApplication (Metadata SourceInfo) (Expr t) [Expr t] t
+            | ForeignFnApplication (Metadata SourceInfo) (Expr t) [Expr t] t
             | Fn (Metadata SourceInfo) NameBinding (Expr t) t
             | NoArgFn (Metadata SourceInfo) (Expr t) t
             | Let (Metadata SourceInfo) NameBinding (Expr t) (Expr t) t
@@ -43,7 +43,7 @@ instance HasSourceInfo (Expr t) where
   getSourceInfo (BinaryOp (Metadata si) _ _ _ _)             = si
   getSourceInfo (Application (Metadata si) _ _ _)            = si
   getSourceInfo (NoArgApplication (Metadata si) _ _)         = si
-  getSourceInfo (UncurriedFnApplication (Metadata si) _ _ _) = si
+  getSourceInfo (ForeignFnApplication (Metadata si) _ _ _) = si
   getSourceInfo (Fn (Metadata si) _ _ _)                     = si
   getSourceInfo (NoArgFn (Metadata si) _ _)                  = si
   getSourceInfo (Let (Metadata si) _ _ _ _)                  = si
@@ -63,7 +63,7 @@ instance HasSourceInfo (Expr t) where
   setSourceInfo si (BinaryOp _ p l r t)                = BinaryOp (Metadata si) p l r t
   setSourceInfo si (Application _ f a t)               = Application (Metadata si) f a t
   setSourceInfo si (NoArgApplication _ f t)            = NoArgApplication (Metadata si) f t
-  setSourceInfo si (UncurriedFnApplication _ f a t)    = UncurriedFnApplication (Metadata si) f a t
+  setSourceInfo si (ForeignFnApplication _ f a t)    = ForeignFnApplication (Metadata si) f a t
   setSourceInfo si (Fn _ n b t)                        = Fn (Metadata si) n b t
   setSourceInfo si (NoArgFn _ b t)                     = NoArgFn (Metadata si) b t
   setSourceInfo si (Let _ n v b t)                     = Let (Metadata si) n v b t
@@ -84,7 +84,7 @@ typeOf (UnaryOp _ _ _ t) = t
 typeOf (BinaryOp _ _ _ _ t) = t
 typeOf (Application _ _ _ t) = t
 typeOf (NoArgApplication _ _ t) = t
-typeOf (UncurriedFnApplication _ _ _ t) = t
+typeOf (ForeignFnApplication _ _ _ t) = t
 typeOf (Fn _ _ _ t) = t
 typeOf (NoArgFn _ _ t) = t
 typeOf (Let _ _ _ _ t) = t

--- a/src/Oden/Go.hs
+++ b/src/Oden/Go.hs
@@ -124,7 +124,7 @@ convertType (Basic n True) = Left ("Basic untyped: " ++ n)
 convertType (Pointer _) = Left "Pointers"
 convertType (G.Array _ _) = Left "Arrays"
 convertType (Slice t) = Poly.TSlice missing <$> convertType t
-convertType Interface{} = Right $ Poly.TAny missing
+convertType Interface{} = Right $ Poly.TVar missing (Poly.TV "a") -- TODO: generate fresh names
 convertType (Signature _ (Just _) _ _) = Left "Methods (functions with receivers)"
 convertType (Signature isVariadic Nothing args ret) = do
   as <- mapM convertType args

--- a/src/Oden/Infer.hs
+++ b/src/Oden/Infer.hs
@@ -115,8 +115,7 @@ constraintsExpr env ex = do
 closeOver :: Core.Expr Type -> Core.CanonicalExpr
 closeOver = normalize . generalize empty
 
--- | Unify two types. Order matters in some cases as the first type is the one
--- being subsumed by the second, e.g. when unifying with TAny.
+-- | Unify two types.
 uni :: SourceInfo -> Type -> Type -> Infer ()
 uni si t1 t2 = tell [(si, t1, t2)]
 
@@ -125,7 +124,6 @@ inEnv :: (Identifier, TypeBinding) -> Infer a -> Infer a
 inEnv (x, sc) = local (`extend` (x, sc))
 
 lookupTypeIn :: TypingEnvironment -> Metadata SourceInfo -> Identifier -> Infer Type
-lookupTypeIn _ si (Identifier "any") = return (TAny si)
 lookupTypeIn env (Metadata si) identifier =
   case Environment.lookup identifier env of
     Nothing                     -> throwError $ NotInScope si identifier

--- a/src/Oden/Infer/Substitution.hs
+++ b/src/Oden/Infer/Substitution.hs
@@ -28,7 +28,6 @@ class FTV a => Substitutable a where
   apply :: Subst -> a -> a
 
 instance Substitutable Type where
-  apply _ (TAny si)                     = TAny si
   apply s (TTuple si f s' r)            = TTuple si (apply s f) (apply s s') (apply s r)
   apply _ (TCon si n)                   = TCon si n
   apply (Subst s) t@(TVar _ a)          = Map.findWithDefault t a s

--- a/src/Oden/Infer/Substitution.hs
+++ b/src/Oden/Infer/Substitution.hs
@@ -28,19 +28,18 @@ class FTV a => Substitutable a where
   apply :: Subst -> a -> a
 
 instance Substitutable Type where
-  apply _ (TAny si)               = TAny si
-  apply s (TTuple si f s' r)      = TTuple si (apply s f) (apply s s') (apply s r)
-  apply _ (TCon si n)             = TCon si n
-  apply (Subst s) t@(TVar _ a)    = Map.findWithDefault t a s
-  apply s (TNoArgFn si t)         = TNoArgFn si (apply s t)
-  apply s (TFn si t1 t2)          = TFn si (apply s t1) (apply s t2)
-  apply s (TUncurriedFn si as r)  = TUncurriedFn si (map (apply s) as) (apply s r)
-  apply s (TVariadicFn si as v r) = TVariadicFn si (map (apply s) as) (apply s v) (apply s r)
-  apply s (TSlice si t)           = TSlice si (apply s t)
-  apply s (TRecord si r)          = TRecord si (apply s r)
-  apply _ (REmpty si)             = REmpty si
-  apply s (RExtension si l t r)   = RExtension si l (apply s t) (apply s r)
-  apply s (TNamed si n t)         = TNamed si n (apply s t)
+  apply _ (TAny si)                     = TAny si
+  apply s (TTuple si f s' r)            = TTuple si (apply s f) (apply s s') (apply s r)
+  apply _ (TCon si n)                   = TCon si n
+  apply (Subst s) t@(TVar _ a)          = Map.findWithDefault t a s
+  apply s (TNoArgFn si t)               = TNoArgFn si (apply s t)
+  apply s (TFn si t1 t2)                = TFn si (apply s t1) (apply s t2)
+  apply s (TForeignFn si variadic as r) = TForeignFn si variadic (map (apply s) as) (apply s r)
+  apply s (TSlice si t)                 = TSlice si (apply s t)
+  apply s (TRecord si r)                = TRecord si (apply s r)
+  apply _ (REmpty si)                   = REmpty si
+  apply s (RExtension si l t r)         = RExtension si l (apply s t) (apply s r)
+  apply s (TNamed si n t)               = TNamed si n (apply s t)
 
 instance Substitutable Scheme where
   apply (Subst s) (Forall si as t) =

--- a/src/Oden/Infer/Substitution.hs
+++ b/src/Oden/Infer/Substitution.hs
@@ -72,7 +72,7 @@ instance Substitutable (Core.Expr Type) where
   apply s (Core.BinaryOp si o e1 e2 t)                  = Core.BinaryOp si o (apply s e1) (apply s e2) (apply s t)
   apply s (Core.Application si f p t)                   = Core.Application si (apply s f) (apply s p) (apply s t)
   apply s (Core.NoArgApplication si f t)                = Core.NoArgApplication si (apply s f) (apply s t)
-  apply s (Core.UncurriedFnApplication si f p t)        = Core.UncurriedFnApplication si (apply s f) (apply s p) (apply s t)
+  apply s (Core.ForeignFnApplication si f p t)          = Core.ForeignFnApplication si (apply s f) (apply s p) (apply s t)
   apply s (Core.Fn si x b t)                            = Core.Fn si x (apply s b) (apply s t)
   apply s (Core.NoArgFn si b t)                         = Core.NoArgFn si (apply s b) (apply s t)
   apply s (Core.Let si x e b t)                         = Core.Let si x (apply s e) (apply s b) (apply s t)

--- a/src/Oden/Infer/Subsumption.hs
+++ b/src/Oden/Infer/Subsumption.hs
@@ -46,7 +46,6 @@ collectSubstitutions (TTuple _ f1 s1 r1) (TTuple _ f2 s2 r2) = do
   collectSubstitutions f1 f2
   collectSubstitutions s1 s2
   zipWithM_ collectSubstitutions r1 r2
-collectSubstitutions TAny{} _ = return ()
 collectSubstitutions (TRecord _ r1) (TRecord _ r2) =
   collectSubstitutions r1 r2
 collectSubstitutions r1 r2 | kindOf r1 == Row && kindOf r2 == Row = do

--- a/src/Oden/Infer/Subsumption.hs
+++ b/src/Oden/Infer/Subsumption.hs
@@ -39,10 +39,8 @@ collectSubstitutions (TFn _ a1 r1) (TFn _ a2 r2) = do
   collectSubstitutions a1 a2
   collectSubstitutions r1 r2
 collectSubstitutions (TNoArgFn _ r1) (TNoArgFn _ r2) = collectSubstitutions r1 r2
-collectSubstitutions (TUncurriedFn _ a1 r1) (TUncurriedFn _ a2 r2) =
-  mapM_ (uncurry collectSubstitutions) (zip r1 r2 ++ zip a1 a2)
-collectSubstitutions (TVariadicFn _ a1 v1 r1) (TVariadicFn _ a2 v2 r2) =
-  mapM_ (uncurry collectSubstitutions) ((v1, v2) : (zip a1 a2 ++ zip r1 r2))
+collectSubstitutions (TForeignFn _ _ a1 r1) (TForeignFn _ _ a2 r2) =
+  mapM_ (uncurry collectSubstitutions) (zip a1 a2 ++ zip r1 r2)
 collectSubstitutions (TSlice _ t1) (TSlice _ t2) = collectSubstitutions t1 t2
 collectSubstitutions (TTuple _ f1 s1 r1) (TTuple _ f2 s2 r2) = do
   collectSubstitutions f1 f2

--- a/src/Oden/Infer/Unification.hs
+++ b/src/Oden/Infer/Unification.hs
@@ -75,7 +75,9 @@ unifies si (TTuple _ f1 s1 r1) (TTuple _ f2 s2 r2) = do
   s <- unifies si s1 s2
   r <- unifyMany si r1 r2
   return (f `compose` s `compose` r)
-unifies si (TSlice _ t1) (TSlice _ t2) = unifies si t1 t2
+unifies si (TSlice _ t1@TVar{}) (TSlice _ t2) = unifies si t1 t2
+unifies si (TSlice _ t1) (TSlice _ t2@TVar{}) = unifies si t1 t2
+unifies _ (TSlice _ t1) (TSlice _ t2) | t1 == t2 = return emptySubst
 unifies si (TNamed _ n1 t1) (TNamed _ n2 t2)
   | n1 == n2 = unifies si t1 t2
 unifies si t1 (TNamed _ _ t2) = unifies si t1 t2

--- a/src/Oden/Infer/Unification.hs
+++ b/src/Oden/Infer/Unification.hs
@@ -24,7 +24,6 @@ data UnificationError = UnificationFail SourceInfo Type Type
                       | RowFieldUnificationFail SourceInfo (Identifier, Type) (Identifier, Type)
                       | InfiniteType SourceInfo TVar Type
                       | UnificationMismatch SourceInfo [Type] [Type]
-                      | ParameterCountMismatch SourceInfo Type Type [Type] [Type]
                       deriving (Show, Eq)
 
 type Constraint = (SourceInfo, Type, Type)

--- a/src/Oden/Infer/Unification.hs
+++ b/src/Oden/Infer/Unification.hs
@@ -47,13 +47,10 @@ unifyMany si (t1 : ts1) (t2 : ts2) =
      return (su2 `compose` su1)
 unifyMany si t1 t2 = throwError $ UnificationMismatch si t1 t2
 
--- | Unify two types, returning the resulting substitution. Order matters in
--- some cases as the first type is the one being subsumed by the second, e.g.
--- when unifying with TAny.
+-- | Unify two types, returning the resulting substitution.
 unifies :: SourceInfo -> Type -> Type -> Solve Subst
 unifies _ (TVar _ v) t = v `bind` t
 unifies _ t (TVar _ v) = v `bind` t
-unifies _ TAny{} _ = return emptySubst
 unifies _ (TCon _ n1) (TCon _ n2)
   | n1 == n2 = return emptySubst
 unifies si (TFn _ t1 t2) (TFn _ t3 t4) = unifyMany si [t1, t2] [t3, t4]

--- a/src/Oden/Output.hs
+++ b/src/Oden/Output.hs
@@ -30,12 +30,6 @@ escape OutputSettings{monochrome = False} ns = text ("\ESC[" ++ intercalate ";" 
 strCode :: OutputSettings -> String -> Doc
 strCode settings a = code settings (text a)
 
-pluralize :: String -> Int -> Doc
-pluralize str 1     = text str
-pluralize str _
-  | last str == 's' = text str
-  | otherwise       = text (str ++ "s")
-
 code :: OutputSettings -> Doc -> Doc
 code settings d =
   escape settings [1, 34] <> contents <> escape settings [0]

--- a/src/Oden/Output/Unification.hs
+++ b/src/Oden/Output/Unification.hs
@@ -13,7 +13,6 @@ instance OdenOutput UnificationError where
   name RowFieldUnificationFail{} = "Infer.UnificationFail"
   name InfiniteType{}            = "Infer.InfiniteType"
   name UnificationMismatch{}     = "Infer.UnificationMismatch"
-  name ParameterCountMismatch{}   = "Infer.ArgumentCountMismatch"
 
   header (UnificationFail _ t1 t2) s = text "Cannot unify types"
     <+> code s (pp t1) <+> text "and" <+> code s (pp t2)
@@ -21,13 +20,6 @@ instance OdenOutput UnificationError where
     <+> code s (pp l1) <+> text "and" <+> code s (pp l2)
   header InfiniteType{} _ = text "Cannot construct an infinite type"
   header UnificationMismatch{} _ = text "Types do not match"
-  header (ParameterCountMismatch _ _ _ actual expected) _ =
-    text "Cannot apply a function of"
-    <+> int (length actual)
-    <+> pluralize "parameter" (length actual)
-    <+> text "to"
-    <+> int (length expected)
-    <+> pluralize "argument" (length expected)
 
   details UnificationFail{} _ = empty
   details (RowFieldUnificationFail _ (l1, t1) (l2, t2)) s =
@@ -41,12 +33,8 @@ instance OdenOutput UnificationError where
           formatTypes (t1:ts1) [] = code s (pp t1) <+> text "!= <none>" $+$ formatTypes ts1 []
           formatTypes [] (t2:ts2) = text "<none> !=" <+> code s (pp t2) $+$ formatTypes [] ts2
           formatTypes [] [] = empty
-  details (ParameterCountMismatch _ expectedType actualType _ _) s =
-    text "Expected function type:" <+> code s (pp expectedType)
-    $+$ text "Actual function type:" <+> code s (pp actualType)
 
   sourceInfo (UnificationFail si _ _)            = Just si
   sourceInfo (RowFieldUnificationFail si _ _)    = Just si
   sourceInfo (InfiniteType si _ _)               = Just si
   sourceInfo (UnificationMismatch si _ _)        = Just si
-  sourceInfo (ParameterCountMismatch si _ _ _ _) = Just si

--- a/src/Oden/Predefined.hs
+++ b/src/Oden/Predefined.hs
@@ -25,8 +25,8 @@ typeUnit = TCon predefined (nameInUniverse "unit")
 foreignFns :: [(Identifier, Scheme)]
 foreignFns = [
   (Identifier "len", Forall predefined [TVarBinding predefined (TV "a")] (TForeignFn predefined False [TSlice predefined (TVar predefined (TV "a"))] [typeInt])),
-  (Identifier "print", Forall predefined [] (TForeignFn predefined False [TAny predefined] [typeUnit])),
-  (Identifier "println", Forall predefined [] (TForeignFn predefined False [TAny predefined] [typeUnit]))
+  (Identifier "print", Forall predefined [TVarBinding predefined (TV "a")] (TForeignFn predefined False [TVar predefined (TV "a")] [typeUnit])),
+  (Identifier "println", Forall predefined [TVarBinding predefined (TV "a")] (TForeignFn predefined False [TVar predefined (TV "a")] [typeUnit]))
   ]
 
 types :: [(String, Type)]

--- a/src/Oden/Predefined.hs
+++ b/src/Oden/Predefined.hs
@@ -22,9 +22,11 @@ typeString = TCon predefined (nameInUniverse "string")
 typeBool = TCon predefined (nameInUniverse "bool")
 typeUnit = TCon predefined (nameInUniverse "unit")
 
-functions :: [(Identifier, Scheme)]
-functions = [
-  (Identifier "len", Forall predefined [TVarBinding predefined (TV "a")] (TUncurriedFn predefined [TSlice predefined (TVar predefined (TV "a"))] [typeInt]))
+foreignFns :: [(Identifier, Scheme)]
+foreignFns = [
+  (Identifier "len", Forall predefined [TVarBinding predefined (TV "a")] (TForeignFn predefined False [TSlice predefined (TVar predefined (TV "a"))] [typeInt])),
+  (Identifier "print", Forall predefined [] (TForeignFn predefined False [TAny predefined] [typeUnit])),
+  (Identifier "println", Forall predefined [] (TForeignFn predefined False [TAny predefined] [typeUnit]))
   ]
 
 types :: [(String, Type)]
@@ -40,7 +42,7 @@ universe =
   Core.Package
   (Core.PackageDeclaration (Metadata Missing) [])
   []
-  (map toForeignDef functions ++ map toTypeDef types)
+  (map toForeignDef foreignFns ++ map toTypeDef types)
     where
     toTypeDef (s, t) = Core.TypeDefinition predefined (nameInUniverse s) [] t
     toForeignDef (i, s) = Core.ForeignDefinition predefined i s

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -101,8 +101,8 @@ instance Pretty t => Pretty (Expr t) where
   pp (BinaryOp _ op e1 e2 _) = parens (pp e1 <+> pp op <+> pp e2)
   pp (Application _ f a _) = pp f <> text "(" <> pp a <> text ")"
   pp (NoArgApplication _ f _) = pp f <> text "()"
-  pp (UncurriedFnApplication _ f as _) = pp f <> commaSepParens as
-  pp (Fn _ n b _) = parens (pp n) <+> rArr <+> pp b
+  pp (ForeignFnApplication _ f as _) = pp f <> commaSepParens as
+  pp (Fn _ n b _) = parens (parens (pp n) <+> rArr <+> pp b)
   pp (NoArgFn _ b _) = parens empty <+> rArr <+> pp b
   pp (Let _ n e b _) =
     text "let" <+> pp n <+> equals <+> pp e <+> text "in" <+> pp b
@@ -176,10 +176,10 @@ instance Pretty Poly.Type where
   pp (Poly.TCon _ n) = pp n
   pp (Poly.TNoArgFn _ t) = rArr <+> pp t
   pp (Poly.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
-  pp (Poly.TUncurriedFn _ as [r]) = hsep (intersperse (text "&") (map pp as)) <+> rArr <+> pp r
-  pp (Poly.TUncurriedFn _ as rs) = hsep (intersperse (text "&") (map pp as)) <+> rArr <+> commaSepParens rs
-  pp (Poly.TVariadicFn _ as v [r]) = hsep (intersperse (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
-  pp (Poly.TVariadicFn _ as v rs) = hsep (intersperse (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> commaSepParens rs
+  pp (Poly.TUncurriedFn _ as [r]) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp as)) <+> rArr <+> pp r
+  pp (Poly.TUncurriedFn _ as rs) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp as)) <+> rArr <+> commaSepParens rs
+  pp (Poly.TVariadicFn _ as v [r]) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
+  pp (Poly.TVariadicFn _ as v rs) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> commaSepParens rs
   pp (Poly.TSlice _ t) =
     text "[]" <> braces (pp t)
   pp (Poly.TNamed _ n _) = pp n
@@ -218,12 +218,12 @@ instance Pretty Mono.Type where
   pp (Mono.TCon _ n) = pp n
   pp (Mono.TNoArgFn _ t) = rArr <+> pp t
   pp (Mono.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
-  pp (Mono.TUncurriedFn _ as [r]) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
-  pp (Mono.TUncurriedFn _ as rs) = hsep (punctuate (text "&") (map pp as)) <+> rArr <+> parens (hsep (punctuate (text ", ") (map pp rs)))
-  pp (Mono.TVariadicFn _ as v [r]) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
-  pp (Mono.TVariadicFn _ as v rs) = hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> parens (hsep (punctuate (text ", ") (map pp rs)))
+  pp (Mono.TUncurriedFn _ as [r]) = text "<foreign>" <+> hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
+  pp (Mono.TUncurriedFn _ as rs) = text "<foreign>" <+> hsep (punctuate (text "&") (map pp as)) <+> rArr <+> parens (hsep (punctuate (text ", ") (map pp rs)))
+  pp (Mono.TVariadicFn _ as v [r]) = text "<foreign>" <+> hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
+  pp (Mono.TVariadicFn _ as v rs) = text "<foreign>" <+> hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> parens (hsep (punctuate (text ", ") (map pp rs)))
   pp (Mono.TSlice _ t) =
-    text "!" <> braces (pp t)
+    text "[]" <> braces (pp t)
   pp (Mono.TNamed _ n _) = pp n
   pp (Mono.TRecord _ r) = braces (ppMonoFields r)
   pp Mono.REmpty{} = braces empty

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -169,7 +169,6 @@ instance Pretty QualifiedName where
   pp (FQN pkg identifier) = hcat (punctuate (text ".") (map text pkg ++ [pp identifier]))
 
 instance Pretty Poly.Type where
-  pp (Poly.TAny _) = text "any"
   pp (Poly.TTuple _ f s r) = commaSepParens (f:s:r)
   pp (Poly.TVar _ v) = pp v
   pp (Poly.TCon _ (FQN [] (Identifier "unit"))) = text "()"
@@ -212,7 +211,6 @@ ppReturns [r] = pp r
 ppReturns rs = commaSepParens rs
 
 instance Pretty Mono.Type where
-  pp (Mono.TAny _) = text "any"
   pp (Mono.TTuple _ f s r) =
     brackets (hcat (punctuate (text ", ") (map pp (f:s:r))))
   pp (Mono.TCon _ (FQN [] (Identifier "unit"))) = text "()"

--- a/src/Oden/Pretty.hs
+++ b/src/Oden/Pretty.hs
@@ -176,10 +176,7 @@ instance Pretty Poly.Type where
   pp (Poly.TCon _ n) = pp n
   pp (Poly.TNoArgFn _ t) = rArr <+> pp t
   pp (Poly.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
-  pp (Poly.TUncurriedFn _ as [r]) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp as)) <+> rArr <+> pp r
-  pp (Poly.TUncurriedFn _ as rs) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp as)) <+> rArr <+> commaSepParens rs
-  pp (Poly.TVariadicFn _ as v [r]) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
-  pp (Poly.TVariadicFn _ as v rs) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> commaSepParens rs
+  pp (Poly.TForeignFn _ _ ps rs) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp ps)) <+> rArr <+> ppReturns rs
   pp (Poly.TSlice _ t) =
     text "[]" <> braces (pp t)
   pp (Poly.TNamed _ n _) = pp n
@@ -210,6 +207,10 @@ ppMonoFields r = getPairs r
     pp label <> colon <+> pp type' <> comma <+> getPairs row
   getPairs _ = empty
 
+ppReturns :: Pretty p => [p] -> Doc
+ppReturns [r] = pp r
+ppReturns rs = commaSepParens rs
+
 instance Pretty Mono.Type where
   pp (Mono.TAny _) = text "any"
   pp (Mono.TTuple _ f s r) =
@@ -218,10 +219,7 @@ instance Pretty Mono.Type where
   pp (Mono.TCon _ n) = pp n
   pp (Mono.TNoArgFn _ t) = rArr <+> pp t
   pp (Mono.TFn _ tf ta) = pp tf <+> rArr <+> pp ta
-  pp (Mono.TUncurriedFn _ as [r]) = text "<foreign>" <+> hsep (punctuate (text "&") (map pp as)) <+> rArr <+> pp r
-  pp (Mono.TUncurriedFn _ as rs) = text "<foreign>" <+> hsep (punctuate (text "&") (map pp as)) <+> rArr <+> parens (hsep (punctuate (text ", ") (map pp rs)))
-  pp (Mono.TVariadicFn _ as v [r]) = text "<foreign>" <+> hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> pp r
-  pp (Mono.TVariadicFn _ as v rs) = text "<foreign>" <+> hsep (punctuate (text "&") (map pp as ++ [pp v <> text "*"])) <+> rArr <+> parens (hsep (punctuate (text ", ") (map pp rs)))
+  pp (Mono.TForeignFn _ _ ps rs) = text "<foreign>" <+> hsep (intersperse (text "&") (map pp ps)) <+> rArr <+> ppReturns rs
   pp (Mono.TSlice _ t) =
     text "[]" <> braces (pp t)
   pp (Mono.TNamed _ n _) = pp n

--- a/src/Oden/Type/Monomorphic.hs
+++ b/src/Oden/Type/Monomorphic.hs
@@ -15,11 +15,9 @@ data Type
   | TSlice (Metadata SourceInfo) Type
   | TRecord (Metadata SourceInfo) Type
   | TNamed (Metadata SourceInfo) QualifiedName Type
-  | TUncurriedFn (Metadata SourceInfo) [Type] [Type]
-  | TVariadicFn (Metadata SourceInfo) [Type] Type [Type]
-  -- Row
   | REmpty (Metadata SourceInfo)
   | RExtension (Metadata SourceInfo) Identifier Type Type
+  | TForeignFn (Metadata SourceInfo) Bool [Type] [Type]
   deriving (Show, Eq, Ord)
 
 instance HasSourceInfo Type where
@@ -28,8 +26,7 @@ instance HasSourceInfo Type where
   getSourceInfo (TFn (Metadata si) _ _)           = si
   getSourceInfo (TNoArgFn (Metadata si) _)        = si
   getSourceInfo (TCon (Metadata si) _)            = si
-  getSourceInfo (TUncurriedFn (Metadata si) _ _)  = si
-  getSourceInfo (TVariadicFn (Metadata si) _ _ _) = si
+  getSourceInfo (TForeignFn (Metadata si) _ _ _)  = si
   getSourceInfo (TSlice (Metadata si) _)          = si
   getSourceInfo (TRecord (Metadata si) _)         = si
   getSourceInfo (TNamed (Metadata si) _ _)        = si
@@ -41,8 +38,7 @@ instance HasSourceInfo Type where
   setSourceInfo si (TFn _ a r)           = TFn (Metadata si) a r
   setSourceInfo si (TNoArgFn _ r)        = TNoArgFn (Metadata si) r
   setSourceInfo si (TCon _ n)            = TCon (Metadata si) n
-  setSourceInfo si (TUncurriedFn _ a r)  = TUncurriedFn (Metadata si) a r
-  setSourceInfo si (TVariadicFn _ a v r) = TVariadicFn (Metadata si) a v r
+  setSourceInfo si (TForeignFn _ v p r)  = TForeignFn (Metadata si) v p r
   setSourceInfo si (TSlice _ t)          = TSlice (Metadata si) t
   setSourceInfo si (TRecord _ fs)        = TRecord (Metadata si) fs
   setSourceInfo si (TNamed _ n t)        = TNamed (Metadata si) n t

--- a/src/Oden/Type/Monomorphic.hs
+++ b/src/Oden/Type/Monomorphic.hs
@@ -7,8 +7,7 @@ import           Oden.QualifiedName
 import           Oden.SourceInfo
 
 data Type
-  = TAny (Metadata SourceInfo)
-  | TTuple (Metadata SourceInfo) Type Type [Type]
+  = TTuple (Metadata SourceInfo) Type Type [Type]
   | TCon (Metadata SourceInfo) QualifiedName
   | TNoArgFn (Metadata SourceInfo) Type
   | TFn (Metadata SourceInfo) Type Type
@@ -21,7 +20,6 @@ data Type
   deriving (Show, Eq, Ord)
 
 instance HasSourceInfo Type where
-  getSourceInfo (TAny (Metadata si))              = si
   getSourceInfo (TTuple (Metadata si) _ _ _)      = si
   getSourceInfo (TFn (Metadata si) _ _)           = si
   getSourceInfo (TNoArgFn (Metadata si) _)        = si
@@ -33,7 +31,6 @@ instance HasSourceInfo Type where
   getSourceInfo (REmpty (Metadata si))            = si
   getSourceInfo (RExtension (Metadata si) _ _ _)  = si
 
-  setSourceInfo si (TAny _)              = TAny (Metadata si)
   setSourceInfo si (TTuple _ f s r)      = TTuple (Metadata si) f s r
   setSourceInfo si (TFn _ a r)           = TFn (Metadata si) a r
   setSourceInfo si (TNoArgFn _ r)        = TNoArgFn (Metadata si) r

--- a/src/Oden/Type/Polymorphic.hs
+++ b/src/Oden/Type/Polymorphic.hs
@@ -33,9 +33,8 @@ newtype TVar = TV String
 
 -- | A polymorphic type.
 data Type
-  = TAny (Metadata SourceInfo)
   -- | A type variable.
-  | TVar (Metadata SourceInfo) TVar
+  = TVar (Metadata SourceInfo) TVar
   -- | A tuple, with at least two elements.
   | TTuple (Metadata SourceInfo) Type Type [Type]
   -- | A type constructor.
@@ -64,7 +63,6 @@ data Type
   deriving (Show, Eq, Ord)
 
 instance HasSourceInfo Type where
-  getSourceInfo (TAny (Metadata si))              = si
   getSourceInfo (TVar (Metadata si) _)            = si
   getSourceInfo (TTuple (Metadata si) _ _ _)      = si
   getSourceInfo (TFn (Metadata si) _ _)           = si
@@ -77,7 +75,6 @@ instance HasSourceInfo Type where
   getSourceInfo (RExtension (Metadata si) _ _ _)  = si
   getSourceInfo (TForeignFn (Metadata si) _ _ _)  = si
 
-  setSourceInfo si (TAny _)              = TAny (Metadata si)
   setSourceInfo si (TVar _ v)            = TVar (Metadata si) v
   setSourceInfo si (TTuple _ f s r)      = TTuple (Metadata si) f s r
   setSourceInfo si (TFn _ p r)           = TFn (Metadata si) p r
@@ -127,7 +124,6 @@ getLeafRow e = e
 -- | Converts a polymorphic 'Type' to a monomorphic 'Mono.Type'
 -- and fails if there's any 'TVar' in the type.
 toMonomorphic :: Type -> Either String Mono.Type
-toMonomorphic (TAny si) = Right (Mono.TAny si)
 toMonomorphic (TTuple si f s r) =
   Mono.TTuple si <$> toMonomorphic f
                  <*> toMonomorphic s
@@ -154,7 +150,6 @@ isPolymorphic (Forall _ tvars _) = not (null tvars)
 -- TODO: Use 'toMonomorphic' here and check if it's a Left or Right value?
 -- | Predicate returning if there's any 'TVar' in the 'Type'.
 isPolymorphicType :: Type -> Bool
-isPolymorphicType TAny{} = False
 isPolymorphicType (TTuple _ f s r) = any isPolymorphicType (f:s:r)
 isPolymorphicType (TVar _ _) = True
 isPolymorphicType TCon{} = False
@@ -178,7 +173,6 @@ class FTV a where
   ftv :: a -> Set.Set TVar
 
 instance FTV Type where
-  ftv TAny{}                     = Set.empty
   ftv (TTuple _ f s r)           = ftv (f:s:r)
   ftv TCon{}                     = Set.empty
   ftv (TVar _ a)                 = Set.singleton a

--- a/test/Oden/Compiler/InstantiateSpec.hs
+++ b/test/Oden/Compiler/InstantiateSpec.hs
@@ -56,20 +56,20 @@ identityInt =
   (Poly.TFn missing typeInt typeInt)
 
 lenType :: Poly.Type
-lenType = Poly.TUncurriedFn missing [Poly.TSlice missing tvarA] [typeInt]
+lenType = Poly.TForeignFn missing False [Poly.TSlice missing tvarA] [typeInt]
 
 lenPoly :: Core.Expr Poly.Type
 lenPoly = Core.Symbol missing (Identifier "len") lenType
 
 lenIntType :: Mono.Type
-lenIntType = Mono.TUncurriedFn missing [Mono.TSlice missing monoInt] [monoInt]
+lenIntType = Mono.TForeignFn missing False [Mono.TSlice missing monoInt] [monoInt]
 
 lenInt :: Core.Expr Poly.Type
 lenInt =
   Core.Symbol
   missing
   (Identifier "len")
-  (Poly.TUncurriedFn missing [Poly.TSlice missing typeInt] [typeInt])
+  (Poly.TForeignFn missing False [Poly.TSlice missing typeInt] [typeInt])
 
 pairPoly :: Core.Expr Poly.Type
 pairPoly =

--- a/test/Oden/Compiler/MonomorphizationSpec.hs
+++ b/test/Oden/Compiler/MonomorphizationSpec.hs
@@ -160,10 +160,10 @@ sliceLenDef =
     missing
     (Identifier "slice-len")
     (Poly.Forall missing [] typeInt,
-     Core.UncurriedFnApplication
+     Core.Application
       missing
       (Core.Symbol missing (Identifier "len") (Poly.TUncurriedFn missing [Poly.TSlice missing typeBool] [typeInt]))
-      [Core.Slice missing [Core.Literal missing (Core.Bool True) typeBool] (Poly.TSlice missing typeBool)]
+      (Core.Slice missing [Core.Literal missing (Core.Bool True) typeBool] (Poly.TSlice missing typeBool))
       typeInt)
 
 sliceLenMonomorphed :: MonomorphedDefinition
@@ -172,10 +172,10 @@ sliceLenMonomorphed =
     missing
     (Identifier "slice-len")
     monoInt
-    (Core.UncurriedFnApplication
+    (Core.Application
      missing
      (Core.Symbol missing (Identifier "len") (Mono.TUncurriedFn missing [Mono.TSlice missing monoBool] [monoInt]))
-     [Core.Slice missing [Core.Literal missing (Core.Bool True) monoBool] (Mono.TSlice missing monoBool)]
+     (Core.Slice missing [Core.Literal missing (Core.Bool True) monoBool] (Mono.TSlice missing monoBool))
      monoInt)
 
 letWithShadowing :: Core.Definition

--- a/test/Oden/Compiler/MonomorphizationSpec.hs
+++ b/test/Oden/Compiler/MonomorphizationSpec.hs
@@ -162,7 +162,7 @@ sliceLenDef =
     (Poly.Forall missing [] typeInt,
      Core.Application
       missing
-      (Core.Symbol missing (Identifier "len") (Poly.TUncurriedFn missing [Poly.TSlice missing typeBool] [typeInt]))
+      (Core.Symbol missing (Identifier "len") (Poly.TForeignFn missing False [Poly.TSlice missing typeBool] [typeInt]))
       (Core.Slice missing [Core.Literal missing (Core.Bool True) typeBool] (Poly.TSlice missing typeBool))
       typeInt)
 
@@ -174,7 +174,7 @@ sliceLenMonomorphed =
     monoInt
     (Core.Application
      missing
-     (Core.Symbol missing (Identifier "len") (Mono.TUncurriedFn missing [Mono.TSlice missing monoBool] [monoInt]))
+     (Core.Symbol missing (Identifier "len") (Mono.TForeignFn missing False [Mono.TSlice missing monoBool] [monoInt]))
      (Core.Slice missing [Core.Literal missing (Core.Bool True) monoBool] (Mono.TSlice missing monoBool))
      monoInt)
 

--- a/test/Oden/Compiler/TypeEncoderSpec.hs
+++ b/test/Oden/Compiler/TypeEncoderSpec.hs
@@ -25,13 +25,9 @@ spec =
       encodeTypeInstance (Identifier "foo") (TNoArgFn missing (con "int")) `shouldBe` "foo_inst_to_int"
     it "encodes nested single arrows" $
       encodeTypeInstance (Identifier "foo") (TNoArgFn missing (TNoArgFn missing (con "int"))) `shouldBe` "foo_inst_to_to__int"
-    it "encodes uncurried func" $
-      encodeTypeInstance (Identifier "foo") (TUncurriedFn missing [con "bool", con "int"] [con "string"]) `shouldBe` "foo_inst_bool_to_int_to_string"
-    it "encodes uncurried funcs with multiple return values" $
-      encodeTypeInstance (Identifier "foo") (TUncurriedFn missing [con "bool", con "int"] [con "string", con "int"]) `shouldBe` "foo_inst_bool_to_int_to_tupleof__string__int__"
     it "encodes variadic func" $
-      encodeTypeInstance (Identifier "foo") (TVariadicFn missing [con "bool"] (con "int") [con "string"]) `shouldBe` "foo_inst_bool_to_variadic_int_to_string"
+      encodeTypeInstance (Identifier "foo") (TForeignFn missing True [con "bool", con "int"] [con "string"]) `shouldBe` "foo_inst_bool_to_int_variadic_to_string"
     it "encodes variadic func with multiple return values" $
-      encodeTypeInstance (Identifier "foo") (TVariadicFn missing [con "bool"] (con "int") [con "string", con "int"]) `shouldBe` "foo_inst_bool_to_variadic_int_to_tupleof__string__int__"
+      encodeTypeInstance (Identifier "foo") (TForeignFn missing True [con "bool", con "int"] [con "string", con "int"]) `shouldBe` "foo_inst_bool_to_int_variadic_to_tupleof__string__int__"
     it "encodes slice" $
       encodeTypeInstance (Identifier "foo") (TFn missing (TSlice missing (con "bool")) (TSlice missing (con "int"))) `shouldBe` "foo_inst_sliceof__bool_to_sliceof__int"

--- a/test/Oden/Infer/Fixtures.hs
+++ b/test/Oden/Infer/Fixtures.hs
@@ -31,8 +31,6 @@ tvarB = TVar predefined tvB
 tvarC = TVar predefined tvC
 tvarD = TVar predefined tvD
 
-typeAny = TAny missing
-
 scheme:: Type -> Scheme
 scheme t = Forall (Metadata Predefined) (map (TVarBinding missing) $ Set.toList (ftv t)) t
 
@@ -128,10 +126,6 @@ predefAndMax =  predef `extend` (Identifier "max",
 predefAndMaxVariadic :: TypingEnvironment
 predefAndMaxVariadic = predef `extend` (Identifier "max",
                                         Local predefined (Identifier "max") $ forall [] (typeForeign True [TSlice missing typeInt] [typeInt]))
-
-predefAndIdentityAny :: TypingEnvironment
-predefAndIdentityAny = predef `extend` (Identifier "identity",
-                                        Local predefined (Identifier "identity") $ forall [] (typeFn typeAny typeAny))
 
 fooBarPkgEnv :: TypingEnvironment
 fooBarPkgEnv = predef `extend` (Identifier "foo",

--- a/test/Oden/Infer/Fixtures.hs
+++ b/test/Oden/Infer/Fixtures.hs
@@ -95,7 +95,7 @@ tSymbol                 = Symbol missing
 tOp                     = BinaryOp missing
 tApplication            = Application missing
 tNoArgApplication       = NoArgApplication missing
-tUncurriedFnApplication = UncurriedFnApplication missing
+tForeignFnApplication   = ForeignFnApplication missing
 tFn                     = Fn missing
 tNoArgFn                = NoArgFn missing
 tLet                    = Let missing
@@ -128,11 +128,11 @@ predefAndMax =  predef `extend` (Identifier "max",
 
 predefAndMaxVariadic :: TypingEnvironment
 predefAndMaxVariadic = predef `extend` (Identifier "max",
-                                        Local predefined (Identifier "max") $ forall [] (typeVariadic [] typeInt [typeInt]))
+                                        Local predefined (Identifier "max") $ forall [] (typeVariadic [] (TSlice missing typeInt) [typeInt]))
 
 predefAndIdentityAny :: TypingEnvironment
 predefAndIdentityAny = predef `extend` (Identifier "identity",
-                                        Local predefined (Identifier "identity") $ forall [] (typeUncurried [typeAny] [typeAny]))
+                                        Local predefined (Identifier "identity") $ forall [] (typeFn typeAny typeAny))
 
 fooBarPkgEnv :: TypingEnvironment
 fooBarPkgEnv = predef `extend` (Identifier "foo",

--- a/test/Oden/Infer/Fixtures.hs
+++ b/test/Oden/Infer/Fixtures.hs
@@ -48,8 +48,7 @@ typeSlice = TSlice missing
 intSlice = typeSlice typeInt
 
 typeNoArgFn = TNoArgFn missing
-typeUncurried = TUncurriedFn missing
-typeVariadic = TVariadicFn missing
+typeForeign = TForeignFn missing
 
 typeRecord = TRecord missing
 emptyRow = REmpty missing
@@ -124,11 +123,11 @@ predefAndStringLength =  predef `extend` (Identifier "stringLength",
 
 predefAndMax :: TypingEnvironment
 predefAndMax =  predef `extend` (Identifier "max",
-                                 Local predefined (Identifier "max") $ forall [] (typeUncurried [typeInt, typeInt] [typeInt]))
+                                 Local predefined (Identifier "max") $ forall [] (typeForeign False [typeInt, typeInt] [typeInt]))
 
 predefAndMaxVariadic :: TypingEnvironment
 predefAndMaxVariadic = predef `extend` (Identifier "max",
-                                        Local predefined (Identifier "max") $ forall [] (typeVariadic [] (TSlice missing typeInt) [typeInt]))
+                                        Local predefined (Identifier "max") $ forall [] (typeForeign True [TSlice missing typeInt] [typeInt]))
 
 predefAndIdentityAny :: TypingEnvironment
 predefAndIdentityAny = predef `extend` (Identifier "identity",

--- a/test/Oden/Infer/InferDefinitionSpec.hs
+++ b/test/Oden/Infer/InferDefinitionSpec.hs
@@ -50,9 +50,9 @@ spec = describe "inferDefinition" $ do
                             (uFn (uNameBinding (Identifier "x")) (uSymbol (Identifier "x"))))
 
   it "infers definition with type signature" $
-    inferDefinition empty (uDefinition (Identifier "x") (Just $ implicit (tsSymbol (Identifier "any"))) (uLiteral (uInt 1)))
+    inferDefinition predef (uDefinition (Identifier "x") (Just $ implicit (tsSymbol (Identifier "int"))) (uLiteral (uInt 1)))
     `shouldSucceedWith`
-    tDefinition (Identifier "x") (forall [] typeAny, tLiteral (tInt 1) typeInt)
+    tDefinition (Identifier "x") (forall [] typeInt, tLiteral (tInt 1) typeInt)
 
   it "infers polymorphic definition with type signature" $
     inferDefinition empty (uDefinition (Identifier "id")
@@ -68,12 +68,11 @@ spec = describe "inferDefinition" $ do
                                                 (Just $ implicit (tsSymbol (Identifier "bool")))
                                                 (uLiteral (uInt 1)))
 
-  it "any subsumes int" $
+  it "any is subsumed by int (maybe this will be supported in the future)" $
+    shouldFail $
       inferDefinition empty (uDefinition (Identifier "some-number")
                                                 (Just $ implicit (tsSymbol (Identifier "any")))
                                                 (uLiteral (uInt 1)))
-      `shouldSucceedWith`
-      tDefinition (Identifier "some-number") (forall [] typeAny, tLiteral (tInt 1) typeInt)
 
 
   it "infers twice function with correct type signature" $
@@ -113,7 +112,8 @@ spec = describe "inferDefinition" $ do
         predef
         (uDefinition
          (Identifier "f")
-         (Just $ implicit (tsFn (tsSymbol (Identifier "int")) (tsSymbol (Identifier "any")))) countToZero)
+         (Just $ implicit (tsFn (tsSymbol (Identifier "int")) (tsSymbol (Identifier "any"))))
+         countToZero)
 
   it "infers record field access fn definition with type signature" $
     let recordType = typeRecord (rowExt (Identifier "foo") tvarA tvarB)

--- a/test/Oden/Infer/SubsumptionSpec.hs
+++ b/test/Oden/Infer/SubsumptionSpec.hs
@@ -17,27 +17,6 @@ spec :: Spec
 spec =
   describe "subsumedBy" $ do
 
-    it "any is subsumed by any" $
-      scheme typeAny `subsumedBy` Literal (Metadata Predefined) Unit typeAny
-      `shouldSucceedWith`
-      (scheme typeAny, Literal (Metadata Predefined) Unit typeAny)
-
-    it "any is subsumed by int" $
-      scheme typeAny `subsumedBy` Literal (Metadata Predefined) Unit typeUnit
-      `shouldSucceedWith`
-      (scheme typeAny, Literal (Metadata Predefined) Unit typeUnit)
-
-    it "int is not subsumed by any" $
-      shouldFail (scheme typeInt `subsumedBy` Literal (Metadata Predefined) Unit typeAny)
-
-    it "tvar is not subsumed by any" $
-      shouldFail (scheme tvarA `subsumedBy` Literal (Metadata Predefined) Unit typeAny)
-
-    it "any is subsumed by tvar" $
-      scheme typeAny `subsumedBy` Literal (Metadata Predefined) Unit tvarA
-      `shouldSucceedWith`
-      (scheme typeAny, Literal (Metadata Predefined) Unit typeAny)
-
     it "tvar is subsumed by same tvar" $
       scheme tvarA `subsumedBy` Literal (Metadata Predefined) Unit tvarA
       `shouldSucceedWith`

--- a/test/Oden/Infer/UnificationSpec.hs
+++ b/test/Oden/Infer/UnificationSpec.hs
@@ -40,15 +40,6 @@ spec =
       `shouldSucceedWith`
       Subst (singleton (TV "a") tvarB)
 
-    it "unifies []{any} with []{any}" $
-      unify (TSlice missing (TAny missing)) (TSlice missing (TAny missing))
-      `shouldSucceedWith`
-      emptySubst
-
-    it "does not unify []{any} with []{string}" $
-      shouldFail $
-        unify (TSlice missing (TAny missing)) (TSlice missing typeString)
-
     it "unifies { foo: int } with a" $
       let oneFieldRow = RExtension missing (Identifier "foo") typeInt (REmpty missing) in
         unify oneFieldRow tvarA

--- a/test/Oden/Infer/UnificationSpec.hs
+++ b/test/Oden/Infer/UnificationSpec.hs
@@ -35,6 +35,20 @@ spec =
       `shouldSucceedWith`
       Subst (fromList [(TV "a", typeInt), (TV "b", typeString)])
 
+    it "unifies []{a} with []{b}" $
+      unify (TSlice missing tvarA) (TSlice missing tvarB)
+      `shouldSucceedWith`
+      Subst (singleton (TV "a") tvarB)
+
+    it "unifies []{any} with []{any}" $
+      unify (TSlice missing (TAny missing)) (TSlice missing (TAny missing))
+      `shouldSucceedWith`
+      emptySubst
+
+    it "does not unify []{any} with []{string}" $
+      shouldFail $
+        unify (TSlice missing (TAny missing)) (TSlice missing typeString)
+
     it "unifies { foo: int } with a" $
       let oneFieldRow = RExtension missing (Identifier "foo") typeInt (REmpty missing) in
         unify oneFieldRow tvarA

--- a/test/Oden/InferSpec.hs
+++ b/test/Oden/InferSpec.hs
@@ -130,19 +130,6 @@ spec = describe "inferExpr" $ do
      (tLiteral (tBool True) typeBool)
      typeBool)
 
-  it "infers fn application with any-type" $
-    inferExpr
-      predefAndIdentityAny
-      (uApplication
-       (uSymbol (Identifier "identity"))
-       [uLiteral (uBool False)])
-    `shouldSucceedWith`
-    (forall [] typeAny,
-     tApplication
-      (tSymbol (Identifier "identity") (typeFn typeAny typeAny))
-      (tLiteral (tBool False) typeBool)
-      typeAny)
-
   it "infers 1 + 1" $
     inferExpr
       predef
@@ -157,24 +144,6 @@ spec = describe "inferExpr" $ do
       (tLiteral (tInt 1) typeInt)
       (tLiteral (tInt 1) typeInt)
       typeInt)
-
-  it "infers fn application with any-type with multiple \"instances\"" $
-    inferExpr
-      predefAndIdentityAny
-      (uApplication
-       (uSymbol (Identifier "identity"))
-       [uApplication
-        (uSymbol (Identifier "identity"))
-        [uLiteral (uBool False)]])
-    `shouldSucceedWith`
-    (forall [] typeAny,
-     tApplication
-      (tSymbol (Identifier "identity") (typeFn typeAny typeAny))
-      (tApplication
-       (tSymbol (Identifier "identity") (typeFn typeAny typeAny))
-       (tLiteral (tBool False) typeBool)
-       typeAny)
-      typeAny)
 
   it "infers let" $
     inferExpr empty (uLet (uNameBinding (Identifier "x")) (uLiteral (uInt 1)) (uSymbol (Identifier "x")))

--- a/test/Oden/InferSpec.hs
+++ b/test/Oden/InferSpec.hs
@@ -218,7 +218,7 @@ spec = describe "inferExpr" $ do
      tApplication
      (tFn (tNameBinding (Identifier "_g0"))
       (tForeignFnApplication
-       (Core.Symbol missing (Identifier "len") (TUncurriedFn missing [TSlice predefined typeBool] [typeInt]))
+       (Core.Symbol missing (Identifier "len") (typeForeign False [TSlice predefined typeBool] [typeInt]))
        [tSymbol (Identifier "_g0") (TSlice predefined typeBool)]
        typeInt)
       (typeFn (TSlice predefined typeBool) typeInt))
@@ -238,7 +238,7 @@ spec = describe "inferExpr" $ do
        (tFn
         (tNameBinding (Identifier "_g1"))
         (tForeignFnApplication
-         (tSymbol (Identifier "max") (typeUncurried [typeInt, typeInt] [typeInt]))
+         (tSymbol (Identifier "max") (typeForeign False [typeInt, typeInt] [typeInt]))
          [tSymbol (Identifier "_g0") typeInt, tSymbol (Identifier "_g1") typeInt]
          typeInt)
         (typeFn typeInt typeInt))
@@ -260,7 +260,7 @@ spec = describe "inferExpr" $ do
      (tFn
       (tNameBinding (Identifier "_g0"))
       (tForeignFnApplication
-       (tSymbol (Identifier "max") (typeVariadic [] (TSlice missing typeInt) [typeInt]))
+       (tSymbol (Identifier "max") (typeForeign True [TSlice missing typeInt] [typeInt]))
        [tSymbol (Identifier "_g0") (TSlice missing typeInt)]
        typeInt)
       (typeFn (TSlice missing typeInt) typeInt))
@@ -275,7 +275,7 @@ spec = describe "inferExpr" $ do
      (tFn
       (tNameBinding (Identifier "_g0"))
       (tForeignFnApplication
-       (tSymbol (Identifier "max") (typeVariadic [] (TSlice missing typeInt) [typeInt]))
+       (tSymbol (Identifier "max") (typeForeign True [TSlice missing typeInt] [typeInt]))
        [tSymbol (Identifier "_g0") (TSlice missing typeInt)]
        typeInt)
       (typeFn (TSlice missing typeInt) typeInt))

--- a/test/Oden/Type/PolymorphicSpec.hs
+++ b/test/Oden/Type/PolymorphicSpec.hs
@@ -20,13 +20,13 @@ typeInt = TCon missing (nameInUniverse "int")
 spec = do
   describe "underlying" $ do
     it "returns unnamed types as-is" $
-      underlying (TAny missing) `shouldBe` (TAny missing)
+      underlying typeInt `shouldBe` typeInt
 
     it "returns the underlying named type one level down" $
-      underlying (named "A" $ TAny missing) `shouldBe` (TAny missing)
+      underlying (named "A" typeInt) `shouldBe` typeInt
 
     it "returns the underlying named type one level down" $
-      underlying (named "A" $ named "B" $ TAny missing) `shouldBe` (TAny missing)
+      underlying (named "A" $ named "B" typeInt) `shouldBe` typeInt
 
   describe "rowToList" $ do
     it "return an empty list for an empty row" $


### PR DESCRIPTION
* TUncurriedFn and TVariadicFn are merged into TForeignFn.
* Foreign fn applications are wrapped in Oden functions at call sites, enabling curried use of Go functions.
* Variadic Go functions take slices, no variadic application from Oden.
* The `any` type is removed.
* Built-in `print` and `println` added as a prelude in each compiled Go package. These take a single type variable argument. Quite a hack for now, but because of [how slices work in Go](https://github.com/golang/go/wiki/InterfaceSlice) the imported `fmt.Print*` functions are very clunky to use from Oden.