### PR TITLE
Fixed regression tests

### DIFF
--- a/regression-test/src/blocks/main.oden
+++ b/regression-test/src/blocks/main.oden
@@ -1,7 +1,5 @@
 package blocks/main
 
-import fmt
-
 result = {
   println("Calculating...")
   42

--- a/regression-test/src/comments/main.oden
+++ b/regression-test/src/comments/main.oden
@@ -1,7 +1,5 @@
 package comments/main
 
-import fmt
-
 /* this is a multiline comment */
 // this is a single line comment
 

--- a/regression-test/src/definitions/main.oden
+++ b/regression-test/src/definitions/main.oden
@@ -1,7 +1,5 @@
 package definitions/main
 
-import fmt
-
 hello = "Hello"
 
 helloWorld = hello ++ ", world!"

--- a/regression-test/src/factorial/main.oden
+++ b/regression-test/src/factorial/main.oden
@@ -1,7 +1,5 @@
 package factorial/main
 
-import fmt
-
 factorial(n) = if n < 2 then 1 else n * factorial(n - 1)
 
 main() = println(factorial(5))

--- a/regression-test/src/fibonacci/main.oden
+++ b/regression-test/src/fibonacci/main.oden
@@ -1,7 +1,5 @@
 package fibonacci/main
 
-import fmt
-
 fib(n) = if n == 1 then 0 else {
   if n == 2 then 1 else {
     fib(n - 1) + fib(n - 2)

--- a/regression-test/src/higherorder/main.oden
+++ b/regression-test/src/higherorder/main.oden
@@ -1,7 +1,5 @@
 package higherorder/main
 
-import fmt
-
 identity(x) = x
 
 applyTo1(x) = x(1)

--- a/regression-test/src/let/main.oden
+++ b/regression-test/src/let/main.oden
@@ -1,5 +1,3 @@
 package let/main
 
-import fmt
-
 main() = println(let name = "Foo" in name ++ "!")

--- a/regression-test/src/letpoly/main.oden
+++ b/regression-test/src/letpoly/main.oden
@@ -1,7 +1,5 @@
 package letpoly/main
 
-import fmt
-
 identity(x) = x
 
 main() = println(let id = identity(identity) in id("a"))

--- a/regression-test/src/letreuse.oden
+++ b/regression-test/src/letreuse.oden
@@ -1,7 +1,5 @@
 package letreuse/main
 
-import fmt
-
 id : forall a. a -> a
 id(x) = let t = (v) -> v in t(x)
 

--- a/regression-test/src/logic/main.oden
+++ b/regression-test/src/logic/main.oden
@@ -1,5 +1,3 @@
 package logic/main
 
-import fmt
-
 main() = println(if !(true && false) || false then "yey" else "ney")

--- a/regression-test/src/numbers/main.oden
+++ b/regression-test/src/numbers/main.oden
@@ -1,7 +1,5 @@
 package numbers/main
 
-import fmt
-
 plus(x, y) = x + y
 
 plus1 = plus(1)

--- a/regression-test/src/pair/main.oden
+++ b/regression-test/src/pair/main.oden
@@ -1,7 +1,5 @@
 package pair/main
 
-import fmt
-
 pair(x, y, f) = f(x, y)
 
 first(p) = p((x, y) -> x)

--- a/regression-test/src/pairlet/main.oden
+++ b/regression-test/src/pairlet/main.oden
@@ -1,7 +1,5 @@
 package pairlet/main
 
-import fmt
-
 pair(x, y, f) = f(x, y)
 
 first(p) = p((x, y) -> x)

--- a/regression-test/src/records.oden
+++ b/regression-test/src/records.oden
@@ -1,7 +1,5 @@
 package records/main
 
-import fmt
-
 type Foo = { name: string }
 type Bar = { foo: Foo }
 

--- a/regression-test/src/rowvar.oden
+++ b/regression-test/src/rowvar.oden
@@ -1,7 +1,5 @@
 package rowvar/main
 
-import fmt
-
 getBar : forall a r. { bar: a | r } -> a
 getBar(r) = r.bar
 

--- a/regression-test/src/slices/main.oden
+++ b/regression-test/src/slices/main.oden
@@ -1,7 +1,5 @@
 package slices/main
 
-import fmt
-
 main : -> ()
 main() = let x = -200 in {
   print(-x)

--- a/regression-test/src/tuples/main.oden
+++ b/regression-test/src/tuples/main.oden
@@ -1,7 +1,5 @@
 package tuples/main
 
-import fmt
-
 nothing = ()
 
 stuff : (int, (), string)

--- a/regression-test/src/typealias.oden
+++ b/regression-test/src/typealias.oden
@@ -1,7 +1,5 @@
 package typealias/main
 
-import fmt
-
 // Oden does not support polymorphic type definitions yet.
 type IntPair = (int -> int -> int) -> int
 

--- a/regression-test/src/typesig/main.oden
+++ b/regression-test/src/typesig/main.oden
@@ -1,7 +1,5 @@
 package typesig/main
 
-import fmt
-
 identityNoTypeSig(x) = x
 
 identityExplicit : forall a. a -> a

--- a/regression-test/src/unicode/main.oden
+++ b/regression-test/src/unicode/main.oden
@@ -1,7 +1,5 @@
 package unicode/main
 
-import fmt
-
 main() = {
   println("As a [Swede], \229äö is what I want to write. \\\\ \"oh yeah\"")
 }

--- a/regression-test/src/unit/main.oden
+++ b/regression-test/src/unit/main.oden
@@ -1,7 +1,5 @@
 package unit/main
 
-import fmt
-
 testing = ()
 
 main() = println("wtf...")

--- a/regression-test/src/void/main.oden
+++ b/regression-test/src/void/main.oden
@@ -1,7 +1,5 @@
 package void/main
 
-import fmt
-
 main() =
   let
     x = print("unit: ")


### PR DESCRIPTION
Almost all of the regression tests where importing the fmt package,
which breaks them and is unnecessary since print and println were
added.