### PR TITLE
Added CLI command to print types

### DIFF
--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -35,4 +35,5 @@ main = do
     Right (opts, ["lint", path]) -> exec opts (lint path)
     Right (opts, ["print-inferred", path]) -> exec opts (printInferred path)
     Right (opts, ["print-compiled", path]) -> exec opts (printCompiled path)
+    Right (opts, ["print-types", path]) -> exec opts (printTypes path)
     Right _ -> putStrLn help

--- a/cli/Oden/CLI/PrintPackage.hs
+++ b/cli/Oden/CLI/PrintPackage.hs
@@ -6,6 +6,8 @@ import           Oden.Scanner
 import           Oden.CLI
 import           Oden.CLI.Build
 
+import           Oden.Core
+
 import           Control.Monad.Reader
 
 import           Text.PrettyPrint.Leijen
@@ -17,6 +19,14 @@ printInferred :: FilePath -> CLI ()
 printInferred path = do
   pkg <- inferFile (OdenSourceFile path ["main"])
   liftIO $ putStrLn $ render $ pretty pkg
+
+printTypes :: FilePath -> CLI ()
+printTypes path = do
+  (Package _ _ definitions) <- inferFile (OdenSourceFile path ["main"])
+  liftIO $ putStrLn $ render $ vcat $ map prettyScheme definitions
+  where
+    prettyScheme (Definition _ name (scheme, _)) = pretty name <+> text ":" <+> pretty scheme
+    prettyScheme _ = empty
 
 printCompiled :: FilePath -> CLI ()
 printCompiled path = do


### PR DESCRIPTION
I was playing around with the sublime plugin and this command would be handy. It is basically the same as print-inferred with only the type definitions.