### PR TITLE
Validate main package

### DIFF
--- a/doc/user-guide/src/the-language.md
+++ b/doc/user-guide/src/the-language.md
@@ -56,7 +56,8 @@ denoted by a name, an equals sign, and the expression to bind the name to.
 The following program imports the `strconv` package from Go, defines a
 function `shout` and a value `result`, and defines the *main* function, the
 entry point of the program. The main function must be a function taking
-no argument and returning `()`, i.e. have the type `(-> ())`.
+no argument and returning `()`, i.e. have the type `(-> ())`. It must also be
+defined in the *main* package.
 
 ```{.oden .playground-runnable language=oden include=src/listings/package-example.oden}
 ```

--- a/src/Oden/Core/Definition.hs
+++ b/src/Oden/Core/Definition.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 module Oden.Core.Definition where
 
 import           Oden.Core.Expr
@@ -16,3 +17,21 @@ data Definition e
   | ProtocolDefinition (Metadata SourceInfo) QualifiedName Protocol
   | Implementation (Metadata SourceInfo) (ProtocolImplementation e)
   deriving (Show, Eq, Ord)
+
+instance HasSourceInfo (Definition e) where
+  getSourceInfo =
+    \case
+      Definition (Metadata si) _ _         -> si
+      ForeignDefinition (Metadata si) _ _  -> si
+      TypeDefinition (Metadata si) _ _ _   -> si
+      ProtocolDefinition (Metadata si) _ _ -> si
+      Implementation (Metadata si) _       -> si
+
+  setSourceInfo si =
+    \case
+      Definition _ q se        -> Definition (Metadata si) q se
+      ForeignDefinition _ q s  -> ForeignDefinition (Metadata si) q s
+      TypeDefinition _ q nb t  -> TypeDefinition (Metadata si) q nb t
+      ProtocolDefinition _ q p -> ProtocolDefinition (Metadata si) q p
+      Implementation _ p       -> Implementation (Metadata si) p
+

--- a/src/Oden/Output/Compiler/Validation/Typed.hs
+++ b/src/Oden/Output/Compiler/Validation/Typed.hs
@@ -11,11 +11,13 @@ import           Oden.SourceInfo
 instance OdenOutput ValidationError where
   outputType _ = Error
 
-  name ValueDiscarded{}            = "Compiler.Validation.ValueDiscarded"
-  name DivisionByZero{}            = "Compiler.Validation.DivisionByZero"
-  name NegativeSliceIndex{}        = "Compiler.Validation.NegativeSliceIndex"
-  name InvalidSubslice{}           = "Compiler.Validation.InvalidSubslice"
-  name UnusedImport{}              = "Compiler.Validation.UnusedImport"
+  name ValueDiscarded{}                 = "Compiler.Validation.ValueDiscarded"
+  name DivisionByZero{}                 = "Compiler.Validation.DivisionByZero"
+  name NegativeSliceIndex{}             = "Compiler.Validation.NegativeSliceIndex"
+  name InvalidSubslice{}                = "Compiler.Validation.InvalidSubslice"
+  name UnusedImport{}                   = "Compiler.Validation.UnusedImport"
+  name MainPkgDoesNotHaveMainFn{}       = "Compiler.Validation.MainPkgDoesNotHaveMainFn"
+  name MainPkgDoesNotHaveValidMainFn{}  = "Compiler.Validation.MainPkgDoesNotHaveValidMainFn"
 
   header (ValueDiscarded e) s =
     text "Value of type"
@@ -32,19 +34,28 @@ instance OdenOutput ValidationError where
     <+> code s (pretty r)
   header (UnusedImport _ _ pkg) s =
     text "Package" <+> code s (pretty pkg) <+> text "imported but not used"
+  header (MainPkgDoesNotHaveMainFn _) _ =
+    text "Package main does not have a main function"
+  header (MainPkgDoesNotHaveValidMainFn _) _ =
+    text "Package main does not have a main function with the valid signature"
+
+  details ValueDiscarded{} _                 = empty
+  details DivisionByZero{} _                 = empty
+  details NegativeSliceIndex{} _             = text "Indices must be >= 0"
+  details InvalidSubslice{} _                = text "Ranges must go from smaller to bigger"
+  details UnusedImport{} _                   = empty
+  details MainPkgDoesNotHaveMainFn{} _       = empty
+  details MainPkgDoesNotHaveValidMainFn{} _  = text "Every main package must have main function with signature:  main : -> ()"
 
 
-  details ValueDiscarded{} _            = empty
-  details DivisionByZero{} _            = empty
-  details NegativeSliceIndex{} _        = text "Indices must be >= 0"
-  details InvalidSubslice{} _           = text "Ranges must go from smaller to bigger"
-  details UnusedImport{} _              = empty
+  sourceInfo (ValueDiscarded e)                 = Just (getSourceInfo e)
+  sourceInfo (DivisionByZero e)                 = Just (getSourceInfo e)
+  sourceInfo (NegativeSliceIndex e)             = Just (getSourceInfo e)
+  sourceInfo (InvalidSubslice si _)             = Just si
+  sourceInfo (UnusedImport si _ _)              = Just si
+  sourceInfo (MainPkgDoesNotHaveMainFn si)      = Just si
+  sourceInfo (MainPkgDoesNotHaveValidMainFn si) = Just si
 
-  sourceInfo (ValueDiscarded e)               = Just (getSourceInfo e)
-  sourceInfo (DivisionByZero e)               = Just (getSourceInfo e)
-  sourceInfo (NegativeSliceIndex e)           = Just (getSourceInfo e)
-  sourceInfo (InvalidSubslice si _)           = Just si
-  sourceInfo (UnusedImport si _ _)            = Just si
 
 instance OdenOutput ValidationWarning where
   outputType _ = Warning


### PR DESCRIPTION
This is a possible fix to #91. With this PR we validate the main package checking for a `main` function with the correct type signature. This PR should fix #106 as well, because as far as I understand the snippet in #106 is not seen as a block, because it must contain at least an expression, but as a record with no fields.

I'm a Haskell newbie :sweat_smile:, so the code is not gonna be that cool, but suggestions are more than welcome :smile:.
### Checklist

These are things that must be checked off before the pull request can be
accepted. 
- [x] `make test` pass
- [x] `make regression-test` pass
- [x] `make lint` pass
- [x] No GHC warnings (do a `stack build --force-dirty` to get a full rebuild)
- [x] User Guide updated _(if applicable)_
- [ ] Code reviewed _(by someone other than the pull request author)_
